### PR TITLE
Fixed null reference with RemoveComponent<T>

### DIFF
--- a/src/EcsRx/Entities/Entity.cs
+++ b/src/EcsRx/Entities/Entity.cs
@@ -56,7 +56,7 @@ namespace EcsRx.Entities
         { RemoveComponents(component); }
 
         public void RemoveComponent<T>() where T : class, IComponent
-        { RemoveComponents(default(T)); }
+        { RemoveComponents(GetComponent<T>()); }
 
         public void RemoveComponents(params IComponent[] components)
         {


### PR DESCRIPTION
RemoveComponent<T>() was sending a null reference to RemoveComponents(). Fixed it to send the component instead.