### PR TITLE
Bug fix: GetEntitiesFor breaks with default parameter NoPoolDefined

### DIFF
--- a/src/EcsRx/Collections/EntityCollectionManager.cs
+++ b/src/EcsRx/Collections/EntityCollectionManager.cs
@@ -119,7 +119,7 @@ namespace EcsRx.Collections
             if(group is EmptyGroup)
             { return new IEntity[0]; }
 
-            if (collectionId == PoolLookups.NoPoolDefined)
+            if (collectionId == PoolLookups.DefaultPoolId)
             { return _collections[collectionId].MatchingGroup(group); }
 
             return Collections.GetAllEntities().MatchingGroup(group);


### PR DESCRIPTION
Found this while updating ecsrx.roguelike2d to latest version.  Couldn't find any other uses of the function, so took a guess at what the intention was.