### PR TITLE
quick and dirty fix to be able to pin unmanaged component pool in memory (break IComponent<> covariance)

### DIFF
--- a/src/EcsRx.Examples/ExampleApps/Playground/ClassBased/Class3Application.cs
+++ b/src/EcsRx.Examples/ExampleApps/Playground/ClassBased/Class3Application.cs
@@ -7,17 +7,12 @@ namespace EcsRx.Examples.ExampleApps.Playground.ClassBased
 {
     public class Class3Application : BasicLoopApplication
     {
-        protected ClassComponent[] Basic1Components;
-        protected ClassComponent2[] Basic2Components;
-        
         protected override void SetupEntities()
         {
             _componentDatabase.PreAllocateComponents(ClassComponent1TypeId, EntityCount);
             _componentDatabase.PreAllocateComponents(ClassComponent2TypeId, EntityCount);
             base.SetupEntities();
 
-            Basic1Components = _componentDatabase.GetComponents<ClassComponent>(ClassComponent1TypeId);
-            Basic2Components = _componentDatabase.GetComponents<ClassComponent2>(ClassComponent2TypeId);
         }
 
         protected override string Description { get; } =
@@ -31,6 +26,9 @@ namespace EcsRx.Examples.ExampleApps.Playground.ClassBased
         
         protected override void RunProcess()
         {
+            var Basic1Components = _componentDatabase.GetComponents<ClassComponent>(ClassComponent1TypeId);
+            var Basic2Components = _componentDatabase.GetComponents<ClassComponent2>(ClassComponent2TypeId);
+
             for (var i = _collection.Count - 1; i >= 0; i--)
             {
                 var entity = _collection[i];

--- a/src/EcsRx.Examples/ExampleApps/Playground/StructBased/Struct3Application.cs
+++ b/src/EcsRx.Examples/ExampleApps/Playground/StructBased/Struct3Application.cs
@@ -6,17 +6,12 @@ namespace EcsRx.Examples.ExampleApps.Playground.StructBased
 {
     public class Struct3Application : BasicLoopApplication
     {
-        protected StructComponent[] Components1;
-        protected StructComponent2[] Components2;
-        
         protected override void SetupEntities()
         {
             _componentDatabase.PreAllocateComponents(StructComponent1TypeId, EntityCount);
             _componentDatabase.PreAllocateComponents(StructComponent2TypeId, EntityCount);
             base.SetupEntities();
 
-            Components1 = _componentDatabase.GetComponents<StructComponent>(StructComponent1TypeId);
-            Components2 = _componentDatabase.GetComponents<StructComponent2>(StructComponent2TypeId);
         }
 
         protected override string Description { get; } =
@@ -30,6 +25,9 @@ namespace EcsRx.Examples.ExampleApps.Playground.StructBased
         
         protected override void RunProcess()
         {
+            var Components1 = _componentDatabase.GetComponents<StructComponent>(StructComponent1TypeId);
+            var Components2 = _componentDatabase.GetComponents<StructComponent2>(StructComponent2TypeId);
+
             for (var i = _collection.Count - 1; i >= 0; i--)
             {
                 var entity = _collection[i];

--- a/src/EcsRx.Examples/ExampleApps/Playground/StructBased/Struct3BApplication.cs
+++ b/src/EcsRx.Examples/ExampleApps/Playground/StructBased/Struct3BApplication.cs
@@ -6,17 +6,12 @@ namespace EcsRx.Examples.ExampleApps.Playground.StructBased
 {
     public class Struct3BApplication : BasicLoopApplication
     {
-        protected StructComponent[] Components1;
-        protected StructComponent2[] Components2;
-        
         protected override void SetupEntities()
         {
             _componentDatabase.PreAllocateComponents(StructComponent1TypeId, EntityCount);
             _componentDatabase.PreAllocateComponents(StructComponent2TypeId, EntityCount);
             base.SetupEntities();
 
-            Components1 = _componentDatabase.GetComponents<StructComponent>(StructComponent1TypeId);
-            Components2 = _componentDatabase.GetComponents<StructComponent2>(StructComponent2TypeId);
         }
 
         protected override string Description { get; } =
@@ -30,6 +25,9 @@ namespace EcsRx.Examples.ExampleApps.Playground.StructBased
         
         protected override void RunProcess()
         {
+            var Components1 = _componentDatabase.GetComponents<StructComponent>(StructComponent1TypeId);
+            var Components2 = _componentDatabase.GetComponents<StructComponent2>(StructComponent2TypeId);
+
             for (var i = _collection.Count - 1; i >= 0; i--)
             {
                 var entity = _collection[i];

--- a/src/EcsRx.Examples/ExampleApps/Playground/StructBased/Struct3CApplication.cs
+++ b/src/EcsRx.Examples/ExampleApps/Playground/StructBased/Struct3CApplication.cs
@@ -6,17 +6,12 @@ namespace EcsRx.Examples.ExampleApps.Playground.StructBased
 {
     public class Struct3CApplication : BasicLoopApplication
     {
-        protected StructComponent[] Components1;
-        protected StructComponent2[] Components2;
-        
         protected override void SetupEntities()
         {
             _componentDatabase.PreAllocateComponents(StructComponent1TypeId, EntityCount);
             _componentDatabase.PreAllocateComponents(StructComponent2TypeId, EntityCount);
             base.SetupEntities();
 
-            Components1 = _componentDatabase.GetComponents<StructComponent>(StructComponent1TypeId);
-            Components2 = _componentDatabase.GetComponents<StructComponent2>(StructComponent2TypeId);
         }
 
         protected override string Description { get; } =
@@ -30,6 +25,9 @@ namespace EcsRx.Examples.ExampleApps.Playground.StructBased
         
         protected override void RunProcess()
         {
+            var Components1 = _componentDatabase.GetComponents<StructComponent>(StructComponent1TypeId);
+            var Components2 = _componentDatabase.GetComponents<StructComponent2>(StructComponent2TypeId);
+
             for (var i = _collection.Count - 1; i >= 0; i--)
             {
                 var entity = _collection[i];

--- a/src/EcsRx.Examples/Program.cs
+++ b/src/EcsRx.Examples/Program.cs
@@ -36,9 +36,9 @@ namespace EcsRx.Examples
             //new Struct2Application().StartApplication();
             //new Class3Application().StartApplication();
             //new Struct3Application().StartApplication();
-            //new Class4Application().StartApplication();
-            new Struct4Application().StartApplication();            
-            //new Struct4BApplication().StartApplication();
+            new Class4Application().StartApplication();
+            new Struct4Application().StartApplication();
+            new Struct4BApplication().StartApplication();
 
         }
     }

--- a/src/EcsRx.Plugins.Batching/Builders/BatchBuilder.cs
+++ b/src/EcsRx.Plugins.Batching/Builders/BatchBuilder.cs
@@ -7,13 +7,13 @@ using EcsRx.Entities;
 using EcsRx.Plugins.Batching.Batches;
 
 namespace EcsRx.Plugins.Batching.Builders
-{   
-    public unsafe class BatchBuilder<T1, T2> : IBatchBuilder<T1, T2> 
+{
+    public unsafe class BatchBuilder<T1, T2> : IBatchBuilder<T1, T2>
         where T1 : unmanaged, IComponent
         where T2 : unmanaged, IComponent
     {
         public IComponentDatabase ComponentDatabase { get; }
-        
+
         private readonly int _componentTypeId1, _componentTypeId2;
 
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
@@ -27,11 +27,11 @@ namespace EcsRx.Plugins.Batching.Builders
         {
             var componentArray1 = ComponentDatabase.GetComponents<T1>(_componentTypeId1);
             var componentArray2 = ComponentDatabase.GetComponents<T2>(_componentTypeId2);
-            
+
             var batches = new Batch<T1, T2>[entities.Count];
-            
-            var component1Handle  = GCHandle.Alloc(componentArray1, GCHandleType.Pinned);
-            var component2Handle  = GCHandle.Alloc(componentArray2, GCHandleType.Pinned);
+
+            var component1Handle = ComponentDatabase.Pin<T1>(_componentTypeId1);
+            var component2Handle = ComponentDatabase.Pin<T2>(_componentTypeId2);
             var component1Pointer = (T1*)component1Handle.AddrOfPinnedObject().ToPointer();
             var component2Pointer = (T2*)component2Handle.AddrOfPinnedObject().ToPointer();
 
@@ -42,25 +42,25 @@ namespace EcsRx.Plugins.Batching.Builders
                     var tempBatch = new Batch<T1, T2>[0];
                     return new PinnedBatch<T1, T2>(tempBatch, new GCHandle[0]);
                 }
-                
+
                 var entity = entities[i];
                 var component1Allocation = entity.ComponentAllocations[_componentTypeId1];
                 var component2Allocation = entity.ComponentAllocations[_componentTypeId2];
-                batches[i] = new Batch<T1, T2>(entity.Id, &component1Pointer[component1Allocation], 
+                batches[i] = new Batch<T1, T2>(entity.Id, &component1Pointer[component1Allocation],
                     &component2Pointer[component2Allocation]);
             }
-            
-            return new PinnedBatch<T1, T2>(batches, new[] { component1Handle, component2Handle});
+
+            return new PinnedBatch<T1, T2>(batches, new[] { component1Handle, component2Handle });
         }
     }
-    
-    public unsafe class BatchBuilder<T1, T2, T3> : IBatchBuilder<T1, T2, T3> 
+
+    public unsafe class BatchBuilder<T1, T2, T3> : IBatchBuilder<T1, T2, T3>
         where T1 : unmanaged, IComponent
         where T2 : unmanaged, IComponent
         where T3 : unmanaged, IComponent
     {
         public IComponentDatabase ComponentDatabase { get; }
-        
+
         private readonly int _componentTypeId1, _componentTypeId2, _componentTypeId3;
 
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
@@ -76,15 +76,15 @@ namespace EcsRx.Plugins.Batching.Builders
             var componentArray1 = ComponentDatabase.GetComponents<T1>(_componentTypeId1);
             var componentArray2 = ComponentDatabase.GetComponents<T2>(_componentTypeId2);
             var componentArray3 = ComponentDatabase.GetComponents<T3>(_componentTypeId3);
-            
+
             var batches = new Batch<T1, T2, T3>[entities.Count];
-            var component1Handle  = GCHandle.Alloc(componentArray1, GCHandleType.Pinned);
-            var component2Handle  = GCHandle.Alloc(componentArray2, GCHandleType.Pinned);
-            var component3Handle  = GCHandle.Alloc(componentArray3, GCHandleType.Pinned);
+            var component1Handle = ComponentDatabase.Pin<T1>(_componentTypeId1);
+            var component2Handle = ComponentDatabase.Pin<T2>(_componentTypeId2);
+            var component3Handle = ComponentDatabase.Pin<T3>(_componentTypeId3);
             var component1Pointer = (T1*)component1Handle.AddrOfPinnedObject().ToPointer();
             var component2Pointer = (T2*)component2Handle.AddrOfPinnedObject().ToPointer();
             var component3Pointer = (T3*)component3Handle.AddrOfPinnedObject().ToPointer();
-            
+
             for (var i = 0; i < entities.Count; i++)
             {
                 if (entities.Count != batches.Length)
@@ -92,29 +92,29 @@ namespace EcsRx.Plugins.Batching.Builders
                     var tempBatch = new Batch<T1, T2, T3>[0];
                     return new PinnedBatch<T1, T2, T3>(tempBatch, new GCHandle[0]);
                 }
-                
+
                 var entity = entities[i];
                 var component1Allocation = entity.ComponentAllocations[_componentTypeId1];
                 var component2Allocation = entity.ComponentAllocations[_componentTypeId2];
                 var component3Allocation = entity.ComponentAllocations[_componentTypeId3];
                 batches[i] = new Batch<T1, T2, T3>(
-                    entity.Id, &component1Pointer[component1Allocation], 
+                    entity.Id, &component1Pointer[component1Allocation],
                     &component2Pointer[component2Allocation],
                     &component3Pointer[component3Allocation]);
             }
-            
-            return new PinnedBatch<T1, T2, T3>(batches, new []{ component1Handle, component2Handle, component3Handle});
+
+            return new PinnedBatch<T1, T2, T3>(batches, new[] { component1Handle, component2Handle, component3Handle });
         }
     }
-    
-    public unsafe class BatchBuilder<T1, T2, T3, T4> : IBatchBuilder<T1, T2, T3, T4> 
+
+    public unsafe class BatchBuilder<T1, T2, T3, T4> : IBatchBuilder<T1, T2, T3, T4>
         where T1 : unmanaged, IComponent
         where T2 : unmanaged, IComponent
         where T3 : unmanaged, IComponent
         where T4 : unmanaged, IComponent
     {
         public IComponentDatabase ComponentDatabase { get; }
-        
+
         private readonly int _componentTypeId1, _componentTypeId2, _componentTypeId3, _componentTypeId4;
 
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
@@ -132,18 +132,18 @@ namespace EcsRx.Plugins.Batching.Builders
             var componentArray2 = ComponentDatabase.GetComponents<T2>(_componentTypeId2);
             var componentArray3 = ComponentDatabase.GetComponents<T3>(_componentTypeId3);
             var componentArray4 = ComponentDatabase.GetComponents<T4>(_componentTypeId4);
-            
+
             var batches = new Batch<T1, T2, T3, T4>[entities.Count];
 
-            var component1Handle  = GCHandle.Alloc(componentArray1, GCHandleType.Pinned);
-            var component2Handle  = GCHandle.Alloc(componentArray2, GCHandleType.Pinned);
-            var component3Handle  = GCHandle.Alloc(componentArray3, GCHandleType.Pinned);
-            var component4Handle  = GCHandle.Alloc(componentArray4, GCHandleType.Pinned);
+            var component1Handle = ComponentDatabase.Pin<T1>(_componentTypeId1);
+            var component2Handle = ComponentDatabase.Pin<T2>(_componentTypeId2);
+            var component3Handle = ComponentDatabase.Pin<T3>(_componentTypeId3);
+            var component4Handle = ComponentDatabase.Pin<T4>(_componentTypeId4);
             var component1Pointer = (T1*)component1Handle.AddrOfPinnedObject().ToPointer();
             var component2Pointer = (T2*)component2Handle.AddrOfPinnedObject().ToPointer();
             var component3Pointer = (T3*)component3Handle.AddrOfPinnedObject().ToPointer();
             var component4Pointer = (T4*)component4Handle.AddrOfPinnedObject().ToPointer();
-            
+
             for (var i = 0; i < entities.Count; i++)
             {
                 if (entities.Count != batches.Length)
@@ -151,7 +151,7 @@ namespace EcsRx.Plugins.Batching.Builders
                     var tempBatch = new Batch<T1, T2, T3, T4>[0];
                     return new PinnedBatch<T1, T2, T3, T4>(tempBatch, new GCHandle[0]);
                 }
-                
+
                 var entity = entities[i];
                 var component1Allocation = entity.ComponentAllocations[_componentTypeId1];
                 var component2Allocation = entity.ComponentAllocations[_componentTypeId2];
@@ -161,13 +161,13 @@ namespace EcsRx.Plugins.Batching.Builders
                     entity.Id, &component1Pointer[component1Allocation], &component2Pointer[component2Allocation],
                     &component3Pointer[component3Allocation], &component4Pointer[component4Allocation]);
             }
-            
+
             return new PinnedBatch<T1, T2, T3, T4>(batches,
-                new[] {component1Handle, component2Handle, component3Handle, component4Handle});
+                new[] { component1Handle, component2Handle, component3Handle, component4Handle });
         }
     }
-    
-    public unsafe class BatchBuilder<T1, T2, T3, T4, T5> : IBatchBuilder<T1, T2, T3, T4, T5> 
+
+    public unsafe class BatchBuilder<T1, T2, T3, T4, T5> : IBatchBuilder<T1, T2, T3, T4, T5>
         where T1 : unmanaged, IComponent
         where T2 : unmanaged, IComponent
         where T3 : unmanaged, IComponent
@@ -175,8 +175,8 @@ namespace EcsRx.Plugins.Batching.Builders
         where T5 : unmanaged, IComponent
     {
         public IComponentDatabase ComponentDatabase { get; }
-        
-        private readonly int _componentTypeId1, _componentTypeId2, _componentTypeId3, 
+
+        private readonly int _componentTypeId1, _componentTypeId2, _componentTypeId3,
             _componentTypeId4, _componentTypeId5;
 
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
@@ -196,20 +196,20 @@ namespace EcsRx.Plugins.Batching.Builders
             var componentArray3 = ComponentDatabase.GetComponents<T3>(_componentTypeId3);
             var componentArray4 = ComponentDatabase.GetComponents<T4>(_componentTypeId4);
             var componentArray5 = ComponentDatabase.GetComponents<T5>(_componentTypeId5);
-            
+
             var batches = new Batch<T1, T2, T3, T4, T5>[entities.Count];
 
-            var component1Handle  = GCHandle.Alloc(componentArray1, GCHandleType.Pinned);
-            var component2Handle  = GCHandle.Alloc(componentArray2, GCHandleType.Pinned);
-            var component3Handle  = GCHandle.Alloc(componentArray3, GCHandleType.Pinned);
-            var component4Handle  = GCHandle.Alloc(componentArray4, GCHandleType.Pinned);
-            var component5Handle  = GCHandle.Alloc(componentArray5, GCHandleType.Pinned);
+            var component1Handle = ComponentDatabase.Pin<T1>(_componentTypeId1);
+            var component2Handle = ComponentDatabase.Pin<T2>(_componentTypeId2);
+            var component3Handle = ComponentDatabase.Pin<T3>(_componentTypeId3);
+            var component4Handle = ComponentDatabase.Pin<T4>(_componentTypeId4);
+            var component5Handle = ComponentDatabase.Pin<T5>(_componentTypeId5);
             var component1Pointer = (T1*)component1Handle.AddrOfPinnedObject().ToPointer();
             var component2Pointer = (T2*)component2Handle.AddrOfPinnedObject().ToPointer();
             var component3Pointer = (T3*)component3Handle.AddrOfPinnedObject().ToPointer();
             var component4Pointer = (T4*)component4Handle.AddrOfPinnedObject().ToPointer();
             var component5Pointer = (T5*)component5Handle.AddrOfPinnedObject().ToPointer();
-            
+
             for (var i = 0; i < entities.Count; i++)
             {
                 if (entities.Count != batches.Length)
@@ -217,7 +217,7 @@ namespace EcsRx.Plugins.Batching.Builders
                     var tempBatch = new Batch<T1, T2, T3, T4, T5>[0];
                     return new PinnedBatch<T1, T2, T3, T4, T5>(tempBatch, new GCHandle[0]);
                 }
-                
+
                 var entity = entities[i];
                 var component1Allocation = entity.ComponentAllocations[_componentTypeId1];
                 var component2Allocation = entity.ComponentAllocations[_componentTypeId2];
@@ -231,11 +231,11 @@ namespace EcsRx.Plugins.Batching.Builders
             }
 
             return new PinnedBatch<T1, T2, T3, T4, T5>(batches,
-                new[] { component1Handle, component2Handle, component3Handle, component4Handle, component5Handle});
+                new[] { component1Handle, component2Handle, component3Handle, component4Handle, component5Handle });
         }
     }
-    
-    public unsafe class BatchBuilder<T1, T2, T3, T4, T5, T6> : IBatchBuilder<T1, T2, T3, T4, T5, T6> 
+
+    public unsafe class BatchBuilder<T1, T2, T3, T4, T5, T6> : IBatchBuilder<T1, T2, T3, T4, T5, T6>
         where T1 : unmanaged, IComponent
         where T2 : unmanaged, IComponent
         where T3 : unmanaged, IComponent
@@ -244,8 +244,8 @@ namespace EcsRx.Plugins.Batching.Builders
         where T6 : unmanaged, IComponent
     {
         public IComponentDatabase ComponentDatabase { get; }
-        
-        private readonly int _componentTypeId1, _componentTypeId2, _componentTypeId3, 
+
+        private readonly int _componentTypeId1, _componentTypeId2, _componentTypeId3,
             _componentTypeId4, _componentTypeId5, _componentTypeId6;
 
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
@@ -267,22 +267,22 @@ namespace EcsRx.Plugins.Batching.Builders
             var componentArray4 = ComponentDatabase.GetComponents<T4>(_componentTypeId4);
             var componentArray5 = ComponentDatabase.GetComponents<T5>(_componentTypeId5);
             var componentArray6 = ComponentDatabase.GetComponents<T6>(_componentTypeId6);
-            
+
             var batches = new Batch<T1, T2, T3, T4, T5, T6>[entities.Count];
 
-            var component1Handle  = GCHandle.Alloc(componentArray1, GCHandleType.Pinned);
-            var component2Handle  = GCHandle.Alloc(componentArray2, GCHandleType.Pinned);
-            var component3Handle  = GCHandle.Alloc(componentArray3, GCHandleType.Pinned);
-            var component4Handle  = GCHandle.Alloc(componentArray4, GCHandleType.Pinned);
-            var component5Handle  = GCHandle.Alloc(componentArray5, GCHandleType.Pinned);
-            var component6Handle  = GCHandle.Alloc(componentArray6, GCHandleType.Pinned);
+            var component1Handle = ComponentDatabase.Pin<T1>(_componentTypeId1);
+            var component2Handle = ComponentDatabase.Pin<T2>(_componentTypeId2);
+            var component3Handle = ComponentDatabase.Pin<T3>(_componentTypeId3);
+            var component4Handle = ComponentDatabase.Pin<T4>(_componentTypeId4);
+            var component5Handle = ComponentDatabase.Pin<T5>(_componentTypeId5);
+            var component6Handle = ComponentDatabase.Pin<T6>(_componentTypeId6);
             var component1Pointer = (T1*)component1Handle.AddrOfPinnedObject().ToPointer();
             var component2Pointer = (T2*)component2Handle.AddrOfPinnedObject().ToPointer();
             var component3Pointer = (T3*)component3Handle.AddrOfPinnedObject().ToPointer();
             var component4Pointer = (T4*)component4Handle.AddrOfPinnedObject().ToPointer();
             var component5Pointer = (T5*)component5Handle.AddrOfPinnedObject().ToPointer();
             var component6Pointer = (T6*)component6Handle.AddrOfPinnedObject().ToPointer();
-            
+
             for (var i = 0; i < entities.Count; i++)
             {
                 if (entities.Count != batches.Length)
@@ -290,7 +290,7 @@ namespace EcsRx.Plugins.Batching.Builders
                     var tempBatch = new Batch<T1, T2, T3, T4, T5, T6>[0];
                     return new PinnedBatch<T1, T2, T3, T4, T5, T6>(tempBatch, new GCHandle[0]);
                 }
-                
+
                 var entity = entities[i];
                 var component1Allocation = entity.ComponentAllocations[_componentTypeId1];
                 var component2Allocation = entity.ComponentAllocations[_componentTypeId2];
@@ -304,8 +304,8 @@ namespace EcsRx.Plugins.Batching.Builders
                     &component5Pointer[component5Allocation], &component6Pointer[component6Allocation]);
             }
 
-            return new PinnedBatch<T1, T2, T3, T4, T5, T6>(batches, 
-                new[] { component1Handle, component2Handle, component3Handle, 
+            return new PinnedBatch<T1, T2, T3, T4, T5, T6>(batches,
+                new[] { component1Handle, component2Handle, component3Handle,
                 component4Handle, component5Handle, component6Handle});
         }
     }

--- a/src/EcsRx.Tests/Framework/Pools/ComponentPoolTests.cs
+++ b/src/EcsRx.Tests/Framework/Pools/ComponentPoolTests.cs
@@ -16,7 +16,7 @@ namespace EcsRx.Tests.Framework.Pools
             
             var componentPool = new ComponentPool<TestComponentOne>(initialSize);
             Assert.Equal(componentPool.Count, initialSize);
-            Assert.Equal(componentPool.Components.Length, initialSize);
+            Assert.Equal(componentPool._components.Length, initialSize);
         }
         
         [Fact]
@@ -34,7 +34,7 @@ namespace EcsRx.Tests.Framework.Pools
                 newSize += expansionSize;
 
                 Assert.Equal(componentPool.Count, newSize);
-                Assert.Equal(componentPool.Components.Length, newSize);
+                Assert.Equal(componentPool._components.Length, newSize);
             }            
         }
         
@@ -53,7 +53,7 @@ namespace EcsRx.Tests.Framework.Pools
                 newSize += expansionSize;
 
                 Assert.Equal(componentPool.Count, newSize);
-                Assert.Equal(componentPool.Components.Length, newSize);
+                Assert.Equal(componentPool._components.Length, newSize);
             }            
         }
 
@@ -86,7 +86,7 @@ namespace EcsRx.Tests.Framework.Pools
             
             Assert.Equal(expectedAllocationCount, actualAllocations.Count);
             Assert.All(actualAllocations, x => expectedAllocations.Contains(x));
-            Assert.Equal(expectedAllocationCount, componentPool.Components.Length);
+            Assert.Equal(expectedAllocationCount, componentPool._components.Length);
             Assert.Equal(expectedAllocationCount, componentPool.Count);
         }
     }

--- a/src/EcsRx.Tests/Plugins/Batching/BatchBuilderTests.cs
+++ b/src/EcsRx.Tests/Plugins/Batching/BatchBuilderTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using EcsRx.Collections;
+using EcsRx.Components;
 using EcsRx.Components.Database;
 using EcsRx.Components.Lookups;
 using EcsRx.Entities;
@@ -10,40 +15,94 @@ namespace EcsRx.Tests.Plugins.Batching
 {
     public class BatchBuilderTests
     {
+        private class DummyComponentDatabase : IComponentDatabase
+        {
+            private readonly Dictionary<Type, Array> _components;
+
+            public DummyComponentDatabase(TestStructComponentOne[] c1, TestStructComponentTwo[] c2)
+            {
+                _components = new Dictionary<Type, Array>
+                {
+                    [typeof(TestStructComponentOne)] = c1,
+                    [typeof(TestStructComponentTwo)] = c2
+                };
+            }
+
+            public int Allocate(int componentTypeId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public T Get<T>(int componentTypeId, int allocationIndex) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public Span<T> GetComponents<T>(int componentTypeId) where T : IComponent => (T[])_components[typeof(T)];
+
+            public IComponentPool<T> GetPoolFor<T>(int componentTypeId) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public ref T GetRef<T>(int componentTypeId, int allocationIndex) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public GCHandle Pin<T>(int componentTypeId) where T : IComponent
+            {
+                return GCHandle.Alloc(_components[typeof(T)], GCHandleType.Pinned);
+            }
+
+            public void PreAllocateComponents(int componentTypeId, int allocationSize)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Remove(int componentTypeId, int allocationIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Set<T>(int componentTypeId, int allocationIndex, T component) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         [Fact]
         public unsafe void should_create_batch_with_correct_values()
         {
-            var fakeOne1 = new TestStructComponentOne {Data = 10};
-            var fakeOne2 = new TestStructComponentOne {Data = 20};
-            var fakeOnes = new[] {fakeOne1, fakeOne2};
-            
-            var fakeTwo1 = new TestStructComponentTwo {Data = 1.5f};
-            var fakeTwo2 = new TestStructComponentTwo {Data = 2.6f};
-            var fakeTwos = new[] {fakeTwo1, fakeTwo2};
-            
-            var mockComponentDatabase = Substitute.For<IComponentDatabase>();
-            mockComponentDatabase.GetComponents<TestStructComponentOne>(Arg.Any<int>()).Returns(fakeOnes);
-            mockComponentDatabase.GetComponents<TestStructComponentTwo>(Arg.Any<int>()).Returns(fakeTwos);
-            
+            var fakeOne1 = new TestStructComponentOne { Data = 10 };
+            var fakeOne2 = new TestStructComponentOne { Data = 20 };
+            var fakeOnes = new[] { fakeOne1, fakeOne2 };
+
+            var fakeTwo1 = new TestStructComponentTwo { Data = 1.5f };
+            var fakeTwo2 = new TestStructComponentTwo { Data = 2.6f };
+            var fakeTwos = new[] { fakeTwo1, fakeTwo2 };
+
+            var mockComponentDatabase = new DummyComponentDatabase(fakeOnes, fakeTwos);
+
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
             mockTypeLookup.GetComponentType(typeof(TestStructComponentOne)).Returns(0);
             mockTypeLookup.GetComponentType(typeof(TestStructComponentTwo)).Returns(1);
 
             var fakeEntity1 = Substitute.For<IEntity>();
             fakeEntity1.Id.Returns(1);
-            fakeEntity1.ComponentAllocations.Returns(new[] {0, 0});
-            
+            fakeEntity1.ComponentAllocations.Returns(new[] { 0, 0 });
+
             var fakeEntity2 = Substitute.For<IEntity>();
             fakeEntity2.Id.Returns(2);
-            fakeEntity2.ComponentAllocations.Returns(new[] {1, 1});
-            
-            var fakeEntities = new []{ fakeEntity1, fakeEntity2 };
-            
+            fakeEntity2.ComponentAllocations.Returns(new[] { 1, 1 });
+
+            var fakeEntities = new[] { fakeEntity1, fakeEntity2 };
+
             var batchBuilder = new BatchBuilder<TestStructComponentOne, TestStructComponentTwo>(mockComponentDatabase, mockTypeLookup);
 
             var batch = batchBuilder.Build(fakeEntities);
             var batches = batch.Batches;
-            
+
             Assert.Equal(fakeEntities.Length, batches.Length);
             Assert.Equal(fakeEntities[0].Id, batches[0].EntityId);
             Assert.Equal(fakeOne1.Data, (*batches[0].Component1).Data);

--- a/src/EcsRx.Tests/Plugins/Batching/ReferenceBatchBuilderTests.cs
+++ b/src/EcsRx.Tests/Plugins/Batching/ReferenceBatchBuilderTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using EcsRx.Collections;
+using EcsRx.Components;
 using EcsRx.Components.Database;
 using EcsRx.Components.Lookups;
 using EcsRx.Entities;
@@ -10,39 +15,93 @@ namespace EcsRx.Tests.Plugins.Batching
 {
     public class ReferenceBatchBuilderTests
     {
+        private class DummyComponentDatabase : IComponentDatabase
+        {
+            private readonly Dictionary<Type, Array> _components;
+
+            public DummyComponentDatabase(TestComponentOne[] c1, TestComponentTwo[] c2)
+            {
+                _components = new Dictionary<Type, Array>
+                {
+                    [typeof(TestComponentOne)] = c1,
+                    [typeof(TestComponentTwo)] = c2
+                };
+            }
+
+            public int Allocate(int componentTypeId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public T Get<T>(int componentTypeId, int allocationIndex) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public Span<T> GetComponents<T>(int componentTypeId) where T : IComponent => (T[])_components[typeof(T)];
+
+            public IComponentPool<T> GetPoolFor<T>(int componentTypeId) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public ref T GetRef<T>(int componentTypeId, int allocationIndex) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public GCHandle Pin<T>(int componentTypeId) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+
+            public void PreAllocateComponents(int componentTypeId, int allocationSize)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Remove(int componentTypeId, int allocationIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Set<T>(int componentTypeId, int allocationIndex, T component) where T : IComponent
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         [Fact]
         public void should_create_batch_with_correct_values()
         {
-            var fakeOne1 = new TestComponentOne {Data = "hello"};
-            var fakeOne2 = new TestComponentOne {Data = "hi"};
-            var fakeOnes = new[] {fakeOne1, fakeOne2};
-            
-            var fakeTwo1 = new TestComponentTwo {Data = "goodbye"};
-            var fakeTwo2 = new TestComponentTwo {Data = "bye"};
-            var fakeTwos = new[] {fakeTwo1, fakeTwo2};
-            
-            var mockComponentDatabase = Substitute.For<IComponentDatabase>();
-            mockComponentDatabase.GetComponents<TestComponentOne>(Arg.Any<int>()).Returns(fakeOnes);
-            mockComponentDatabase.GetComponents<TestComponentTwo>(Arg.Any<int>()).Returns(fakeTwos);
-            
+            var fakeOne1 = new TestComponentOne { Data = "hello" };
+            var fakeOne2 = new TestComponentOne { Data = "hi" };
+            var fakeOnes = new[] { fakeOne1, fakeOne2 };
+
+            var fakeTwo1 = new TestComponentTwo { Data = "goodbye" };
+            var fakeTwo2 = new TestComponentTwo { Data = "bye" };
+            var fakeTwos = new[] { fakeTwo1, fakeTwo2 };
+
+            var mockComponentDatabase = new DummyComponentDatabase(fakeOnes, fakeTwos);
+
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
             mockTypeLookup.GetComponentType(typeof(TestComponentOne)).Returns(0);
             mockTypeLookup.GetComponentType(typeof(TestComponentTwo)).Returns(1);
 
             var fakeEntity1 = Substitute.For<IEntity>();
             fakeEntity1.Id.Returns(1);
-            fakeEntity1.ComponentAllocations.Returns(new[] {0, 0});
-            
+            fakeEntity1.ComponentAllocations.Returns(new[] { 0, 0 });
+
             var fakeEntity2 = Substitute.For<IEntity>();
             fakeEntity2.Id.Returns(2);
-            fakeEntity2.ComponentAllocations.Returns(new[] {1, 1});
-            
-            var fakeEntities = new []{ fakeEntity1, fakeEntity2 };
-            
+            fakeEntity2.ComponentAllocations.Returns(new[] { 1, 1 });
+
+            var fakeEntities = new[] { fakeEntity1, fakeEntity2 };
+
             var batchBuilder = new ReferenceBatchBuilder<TestComponentOne, TestComponentTwo>(mockComponentDatabase, mockTypeLookup);
 
             var batches = batchBuilder.Build(fakeEntities);
-                
+
             Assert.Equal(fakeEntities.Length, batches.Length);
             Assert.Equal(fakeEntities[0].Id, batches[0].EntityId);
             Assert.Equal(fakeOne1.Data, batches[0].Component1.Data);

--- a/src/EcsRx/Collections/ComponentPool.cs
+++ b/src/EcsRx/Collections/ComponentPool.cs
@@ -1,22 +1,89 @@
 using System;
 using System.Collections;
+using System.Runtime.InteropServices;
 using EcsRx.Components;
 using EcsRx.MicroRx.Subjects;
 using EcsRx.Pools;
 
 namespace EcsRx.Collections
 {
+    public unsafe class UnmanagedComponentPool<T> : IComponentPool<T>
+        where T : unmanaged, IComponent
+    {
+        public IndexPool IndexPool { get; }
+        private byte[] _components;
+
+        public int Count { get; private set; }
+        public int IndexesRemaining => IndexPool.AvailableIndexes.Count;
+        public int ExpansionSize { get; private set; }
+
+        public IObservable<bool> OnPoolExtending => _onPoolExtending;
+
+        public Span<T> Components => MemoryMarshal.Cast<byte, T>(new Span<byte>(_components, 0, Count * sizeof(T)));
+
+        private readonly Subject<bool> _onPoolExtending;
+
+        public UnmanagedComponentPool(int expansionSize) : this(expansionSize, expansionSize)
+        { }
+
+        public UnmanagedComponentPool(int expansionSize, int initialSize)
+        {
+            Count = initialSize;
+            ExpansionSize = expansionSize;
+            IndexPool = new IndexPool(expansionSize, initialSize);
+            _components = new byte[sizeof(T) * initialSize];
+            _onPoolExtending = new Subject<bool>();
+        }
+
+        public int Allocate()
+        {
+            if (IndexesRemaining == 0)
+            { Expand(); }
+            return IndexPool.AllocateInstance();
+        }
+
+        public void Release(int index) => IndexPool.ReleaseInstance(index);
+
+        public void Set(int index, object value) => _components.SetValue(value, index);
+
+        public void Expand()
+        { Expand(ExpansionSize); }
+
+        public void Expand(int amountToAdd)
+        {
+            var newCount = _components.Length + amountToAdd;
+            var newEntries = new byte[newCount * sizeof(T)];
+            _components.CopyTo(newEntries, 0);
+            IndexPool.Expand(newCount - 1);
+            _components = newEntries;
+            Count = newCount;
+
+            _onPoolExtending.OnNext(true);
+        }
+
+        public void Dispose()
+        { _onPoolExtending?.Dispose(); }
+
+        public GCHandle Pin()
+        {
+            return GCHandle.Alloc(_components, GCHandleType.Pinned);
+        }
+    }
+
     public class ComponentPool<T> : IComponentPool<T>
         where T : IComponent
     {
         public IndexPool IndexPool { get; }
-        public T[] Components { get; private set; }
+        public T[] _components;
         
         public int Count { get; private set; }
         public int IndexesRemaining => IndexPool.AvailableIndexes.Count;
         public int ExpansionSize { get; private set; }
         
         public IObservable<bool> OnPoolExtending => _onPoolExtending;
+
+        public Span<T> Components => new Span<T>(_components, 0, Count);
+
         private readonly Subject<bool> _onPoolExtending;
 
         public ComponentPool(int expansionSize) : this(expansionSize, expansionSize)
@@ -27,7 +94,7 @@ namespace EcsRx.Collections
             Count = initialSize;
             ExpansionSize = expansionSize;
             IndexPool = new IndexPool(expansionSize, initialSize);
-            Components = new T[initialSize];
+            _components = new T[initialSize];
             _onPoolExtending = new Subject<bool>();
         }
 
@@ -40,26 +107,29 @@ namespace EcsRx.Collections
 
         public void Release(int index) => IndexPool.ReleaseInstance(index);
         
-        public void Set(int index, object value) => Components.SetValue(value, index);
+        public void Set(int index, object value) => _components.SetValue(value, index);
 
         public void Expand()
         { Expand(ExpansionSize); }
         
         public void Expand(int amountToAdd)
         {
-            var newCount = Components.Length + amountToAdd;
+            var newCount = _components.Length + amountToAdd;
             var newEntries = new T[newCount];            
-            Components.CopyTo(newEntries, 0);
+            _components.CopyTo(newEntries, 0);
             IndexPool.Expand(newCount-1);
-            Components = newEntries;
+            _components = newEntries;
             Count = newCount;
             
             _onPoolExtending.OnNext(true);
         }
 
-        public IEnumerator GetEnumerator() => Components.GetEnumerator();
-
         public void Dispose()
         { _onPoolExtending?.Dispose(); }
+
+        public GCHandle Pin()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/EcsRx/Collections/IComponentPool.cs
+++ b/src/EcsRx/Collections/IComponentPool.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Runtime.InteropServices;
 using EcsRx.Components;
 
 namespace EcsRx.Collections
@@ -9,20 +10,22 @@ namespace EcsRx.Collections
     /// </summary>
     /// <remarks>This helps speed up access when you want components of the same type</remarks>
     /// <typeparam name="T">Type of component</typeparam>
-    public interface IComponentPool<out T> : IComponentPool, IDisposable
+    public interface IComponentPool<T> : IComponentPool, IDisposable
         where T : IComponent
     {
         /// <summary>
         /// Contiguous block of memory for components 
         /// </summary>
-        T[] Components { get; }
+        Span<T> Components { get; }
+
+        GCHandle Pin();
     }
     
     /// <summary>
     /// Acts as a basic memory block for components of a specific type
     /// </summary>
     /// <remarks>This helps speed up access for components of the same type</remarks>
-    public interface IComponentPool : IEnumerable
+    public interface IComponentPool
     {
         /// <summary>
         /// Amount of components within the pool

--- a/src/EcsRx/Components/Database/ComponentDatabase.cs
+++ b/src/EcsRx/Components/Database/ComponentDatabase.cs
@@ -1,10 +1,24 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using EcsRx.Collections;
 using EcsRx.Components.Lookups;
 
 namespace EcsRx.Components.Database
 {
+    internal static class TypeExtension
+    {
+        public static bool IsFlagType(this TypeInfo typeInfo) => typeInfo.IsValueType && !typeInfo.IsEnum && !typeInfo.IsPrimitive && typeInfo.DeclaredFields.All(f => f.IsStatic);
+
+        public static bool IsUnmanaged(this TypeInfo typeInfo)
+        {
+            return typeInfo.IsEnum || (typeInfo.IsValueType && (typeInfo.IsPrimitive || typeInfo.DeclaredFields.Where(f => !f.IsStatic).All(f => f.FieldType.IsUnmanaged())));
+        }
+
+        public static bool IsUnmanaged(this Type type) => type.GetTypeInfo().IsUnmanaged();
+    }
+
     public class ComponentDatabase : IComponentDatabase
     {
         public int DefaultExpansionAmount { get; }
@@ -21,7 +35,7 @@ namespace EcsRx.Components.Database
 
         public IComponentPool CreatePoolFor(Type type, int initialSize)
         {
-            var componentPoolType = typeof(ComponentPool<>);
+            var componentPoolType = type.IsUnmanaged() ? typeof(UnmanagedComponentPool<>) : typeof(ComponentPool<>);
             Type[] typeArgs = { type };
             var genericComponentPoolType = componentPoolType.MakeGenericType(typeArgs);
             return (IComponentPool)Activator.CreateInstance(genericComponentPoolType, initialSize);
@@ -46,7 +60,7 @@ namespace EcsRx.Components.Database
         public ref T GetRef<T>(int componentTypeId, int allocationIndex) where T : IComponent
         { return ref GetPoolFor<T>(componentTypeId).Components[allocationIndex]; }
 
-        public T[] GetComponents<T>(int componentTypeId) where T : IComponent
+        public Span<T> GetComponents<T>(int componentTypeId) where T : IComponent
         { return GetPoolFor<T>(componentTypeId).Components; }
 
         public void Set<T>(int componentTypeId, int allocationIndex, T component) where T : IComponent
@@ -65,6 +79,11 @@ namespace EcsRx.Components.Database
         {
             var pool = ComponentData[componentTypeId];
             pool.Expand(allocationSize);
+        }
+
+        public GCHandle Pin<T>(int componentTypeId) where T : IComponent
+        {
+            return GetPoolFor<T>(componentTypeId).Pin();
         }
     }
 }

--- a/src/EcsRx/Components/Database/IComponentDatabase.cs
+++ b/src/EcsRx/Components/Database/IComponentDatabase.cs
@@ -1,4 +1,6 @@
-﻿using EcsRx.Collections;
+﻿using System;
+using System.Runtime.InteropServices;
+using EcsRx.Collections;
 
 namespace EcsRx.Components.Database
 {
@@ -6,7 +8,8 @@ namespace EcsRx.Components.Database
     {
         T Get<T>(int componentTypeId, int allocationIndex) where T : IComponent;
         ref T GetRef<T>(int componentTypeId, int allocationIndex) where T : IComponent;
-        T[] GetComponents<T>(int componentTypeId) where T : IComponent;
+        Span<T> GetComponents<T>(int componentTypeId) where T : IComponent;
+        GCHandle Pin<T>(int componentTypeId) where T : IComponent;
         void Set<T>(int componentTypeId, int allocationIndex, T component) where T : IComponent;
         void Remove(int componentTypeId, int allocationIndex);
         int Allocate(int componentTypeId);

--- a/src/EcsRx/EcsRx.csproj
+++ b/src/EcsRx/EcsRx.csproj
@@ -9,6 +9,7 @@
     <Description>A reactive take on the ECS pattern for .net game developers</Description>
     <PackageTags>ecs rx reactive patterns ioc game-development xna monogame unity</PackageTags>
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\**" />
@@ -18,6 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EcsRx.MicroRx\EcsRx.MicroRx.csproj" />

--- a/src/EcsRx/Extensions/IEntityExtensions.cs
+++ b/src/EcsRx/Extensions/IEntityExtensions.cs
@@ -66,7 +66,7 @@ namespace EcsRx.Extensions
         public static T AddComponent<T>(this IEntity entity) where T : class, IComponent, new()
         {
             var component = new T();
-            entity.AddComponents(component);
+            entity.AddComponent(component);
             return component;
         }
         


### PR DESCRIPTION
removed `IComponentPool<out T>` covariance so a lot of stuff break because of
```
        public void AddComponents(IReadOnlyList<IComponent> components)
        {
            var componentTypeIds = new int[components.Count];
            for (var i = 0; i < components.Count; i++)
            {
                var componentTypeId = ComponentTypeLookup.GetComponentType(components[i].GetType());
                var allocationId = ComponentDatabase.Allocate(componentTypeId);
                InternalComponentAllocations[componentTypeId] = allocationId;
                ComponentDatabase.Set(componentTypeId, allocationId, components[i]);
                componentTypeIds[i] = componentTypeId;
            }
            
            _onComponentsAdded.OnNext(componentTypeIds);
        }
```
in Entity.cs (can't down cast to `IComponentPool<IComponent>` anymore). It should be fixable but I think I have done enough non trivial changes here and it might not be a road you want to take ^^"