### PR TITLE
made GroupBindingSystemHandler consider CollectionAffinityAttribute

### DIFF
--- a/build/pack.bat
+++ b/build/pack.bat
@@ -1,4 +1,4 @@
-set version=3.0.1
+set version=3.1.0
 dotnet pack ../src/EcsRx.MicroRx -c Release -o ../../_dist /p:version=%version%
 dotnet pack ../src/SystemsRx -c Release -o ../../_dist /p:version=%version%
 dotnet pack ../src/SystemsRx.Infrastructure -c Release -o ../../_dist /p:version=%version%

--- a/src/EcsRx.Plugins.GroupBinding/Systems/Handlers/GroupBindingSystemHandler.cs
+++ b/src/EcsRx.Plugins.GroupBinding/Systems/Handlers/GroupBindingSystemHandler.cs
@@ -11,6 +11,7 @@ using EcsRx.Groups.Observable;
 using EcsRx.Plugins.GroupBinding.Attributes;
 using EcsRx.Plugins.GroupBinding.Exceptions;
 using EcsRx.Systems;
+using EcsRx.Extensions;
 
 namespace EcsRx.Plugins.GroupBinding.Systems.Handlers
 {
@@ -70,21 +71,21 @@ namespace EcsRx.Plugins.GroupBinding.Systems.Handlers
                 .ToArray();
         }
 
-        public void ProcessProperty(PropertyInfo property, ISystem system)
+        public void ProcessProperty(PropertyInfo property, ISystem system, int[] groupAffinities)
         {
             var possibleGroup = GetGroupAttributeIfAvailable(system, property);
             if (possibleGroup == null) { return; }
                 
-            var observableGroup = ObservableGroupManager.GetObservableGroup(possibleGroup);
+            var observableGroup = ObservableGroupManager.GetObservableGroup(possibleGroup, groupAffinities);
             property.SetValue(system, observableGroup);
         }
 
-        public void ProcessField(FieldInfo field, ISystem system)
+        public void ProcessField(FieldInfo field, ISystem system, int[] groupAffinities)
         {
             var possibleGroup = GetGroupAttributeIfAvailable(system, field);
             if (possibleGroup == null) { return; }
-                
-            var observableGroup = ObservableGroupManager.GetObservableGroup(possibleGroup);
+
+            var observableGroup = ObservableGroupManager.GetObservableGroup(possibleGroup, groupAffinities);
             field.SetValue(system, observableGroup);
         }
         
@@ -96,12 +97,14 @@ namespace EcsRx.Plugins.GroupBinding.Systems.Handlers
 
             if (observableGroupProperties.Length == 0 && observableGroupFields.Length == 0)
             { return; }
-            
+
+            var groupAffinities = system.GetGroupAffinities();
+
             foreach (var observableGroupProperty in observableGroupProperties)
-            { ProcessProperty(observableGroupProperty, system); }
+            { ProcessProperty(observableGroupProperty, system, groupAffinities); }
             
             foreach (var observableGroupField in observableGroupFields)
-            { ProcessField(observableGroupField, system); }
+            { ProcessField(observableGroupField, system, groupAffinities); }
         }
 
         public void DestroySystem(ISystem system)

--- a/src/EcsRx.Tests/Plugins/GroupBinding/Handlers/GroupBindingSystemHandlerTests.cs
+++ b/src/EcsRx.Tests/Plugins/GroupBinding/Handlers/GroupBindingSystemHandlerTests.cs
@@ -91,7 +91,7 @@ namespace EcsRx.Tests.Plugins.GroupBinding.Handlers
             var propertyInfo = dummySystem.GetType().GetProperty(nameof(dummySystem.ObservableGroupA));
             
             try
-            { reactToEntitySystemHandler.ProcessProperty(propertyInfo, dummySystem); }
+            { reactToEntitySystemHandler.ProcessProperty(propertyInfo, dummySystem, null); }
             catch (MissingGroupSystemInterfaceException e)
             {
                 Assert.Equal(e.Member, propertyInfo);
@@ -112,8 +112,8 @@ namespace EcsRx.Tests.Plugins.GroupBinding.Handlers
             reactToEntitySystemHandler.SetupSystem(dummySystem);
 
             // This could be more specific but given other tests it seems fine for now
-            observableGroupManager.Received(2).GetObservableGroup(Arg.Any<TestGroupA>());
-            observableGroupManager.Received(1).GetObservableGroup(Arg.Any<Group>());
+            observableGroupManager.Received(2).GetObservableGroup(Arg.Any<TestGroupA>(), Arg.Any<int[]>());
+            observableGroupManager.Received(1).GetObservableGroup(Arg.Any<Group>(), Arg.Any<int[]>());
         }
     }
 }

--- a/src/EcsRx/Attributes/CollectionAffinityAttribute.cs
+++ b/src/EcsRx/Attributes/CollectionAffinityAttribute.cs
@@ -1,5 +1,4 @@
 using System;
-using EcsRx.Collections;
 using EcsRx.Collections.Database;
 
 namespace EcsRx.Attributes

--- a/src/EcsRx/Extensions/ISystemExtensions.cs
+++ b/src/EcsRx/Extensions/ISystemExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using EcsRx.Attributes;
 using EcsRx.Groups;
 using EcsRx.Systems;
+using SystemsRx.Systems;
 
 namespace EcsRx.Extensions
 {
@@ -11,9 +12,14 @@ namespace EcsRx.Extensions
         public static IGroup GroupFor(this IGroupSystem groupSystem, params Type[] requiredTypes)
         { return new Group(requiredTypes); }
         
-        public static int[] GetGroupAffinities(this IGroupSystem groupSystem)
+        public static int[] GetGroupAffinities(this ISystem system)
         {
-            var affinity = groupSystem.GetType()
+            if (system is null)
+            {
+                throw new ArgumentNullException(nameof(system));
+            }
+
+            var affinity = system.GetType()
                 .GetCustomAttributes(typeof(CollectionAffinityAttribute), true)
                 .FirstOrDefault();
 


### PR DESCRIPTION
I'm not quite sure if it'd be better to maybe have the CollectionIds be an optional parameter for the FromGroup- / FromComponents-Attributes and only pull it from the CollectionAffinityAttribute of the System when falling back on the IGroupSystem.Group property.
For I decided to just always consider it.

I did a minor version bump but theoretically it would have to be a mayor version as the change could be breaking. However since you aren't having individual Version on each plugin and the plugin is very new I felt like that could be neglected to keep the mayor version low.