### PR TITLE
IComponentAccessor notion & single target of netstandard 2.0

### DIFF
--- a/src/EcsRx.Examples/EcsRx.Examples.csproj
+++ b/src/EcsRx.Examples/EcsRx.Examples.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Persistity.Serializers.LazyData.Json" Version="2.0.41" />
     <PackageReference Include="Spectre.Console" Version="0.44.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="SystemsRx.Infrastructure.Ninject" Version="5.0.19" />
-    <PackageReference Include="SystemsRx.ReactiveData" Version="5.0.19" />
+    <PackageReference Include="SystemsRx.Infrastructure.Ninject" Version="5.1.21" />
+    <PackageReference Include="SystemsRx.ReactiveData" Version="5.1.21" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EcsRx.Infrastructure\EcsRx.Infrastructure.csproj">

--- a/src/EcsRx.Examples/ExampleApps/Playground/BasicLoopApplication.cs
+++ b/src/EcsRx.Examples/ExampleApps/Playground/BasicLoopApplication.cs
@@ -34,10 +34,10 @@ namespace EcsRx.Examples.ExampleApps.Playground
             _referenceBatchBuilderFactory = Container.Resolve<IReferenceBatchBuilderFactory>();
             _collection = EntityDatabase.GetCollection();
 
-            ClassComponent1TypeId = _componentTypeLookup.GetComponentType(typeof(ClassComponent));
-            ClassComponent2TypeId = _componentTypeLookup.GetComponentType(typeof(ClassComponent2));
-            StructComponent1TypeId = _componentTypeLookup.GetComponentType(typeof(StructComponent));
-            StructComponent2TypeId = _componentTypeLookup.GetComponentType(typeof(StructComponent2));
+            ClassComponent1TypeId = _componentTypeLookup.GetComponentTypeId(typeof(ClassComponent));
+            ClassComponent2TypeId = _componentTypeLookup.GetComponentTypeId(typeof(ClassComponent2));
+            StructComponent1TypeId = _componentTypeLookup.GetComponentTypeId(typeof(StructComponent));
+            StructComponent2TypeId = _componentTypeLookup.GetComponentTypeId(typeof(StructComponent2));
             
             var name = GetType().Name;
             Console.WriteLine($"{name} - {Description}");

--- a/src/EcsRx.Infrastructure/EcsRx.Infrastructure.csproj
+++ b/src/EcsRx.Infrastructure/EcsRx.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>0.0.0</Version>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>EcsRx.Infrastructure</Title>
     <Authors>Grofit (LP)</Authors>
     <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\EcsRx\EcsRx.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SystemsRx.Infrastructure" Version="5.0.19" />
+    <PackageReference Include="SystemsRx.Infrastructure" Version="5.1.21" />
   </ItemGroup>
 </Project>

--- a/src/EcsRx.Plugins.Batching/Accessors/BatchAccessor.cs
+++ b/src/EcsRx.Plugins.Batching/Accessors/BatchAccessor.cs
@@ -61,8 +61,8 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
             
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
@@ -91,9 +91,9 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
             
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
@@ -125,10 +125,10 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
-            var componentType4 = ComponentTypeLookup.GetComponentType(typeof(T4));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
+            var componentType4 = ComponentTypeLookup.GetComponentTypeId(typeof(T4));
             
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
@@ -163,11 +163,11 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
-            var componentType4 = ComponentTypeLookup.GetComponentType(typeof(T4));
-            var componentType5 = ComponentTypeLookup.GetComponentType(typeof(T5));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
+            var componentType4 = ComponentTypeLookup.GetComponentTypeId(typeof(T4));
+            var componentType5 = ComponentTypeLookup.GetComponentTypeId(typeof(T5));
             
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
@@ -205,12 +205,12 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
-            var componentType4 = ComponentTypeLookup.GetComponentType(typeof(T4));
-            var componentType5 = ComponentTypeLookup.GetComponentType(typeof(T5));
-            var componentType6 = ComponentTypeLookup.GetComponentType(typeof(T6));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
+            var componentType4 = ComponentTypeLookup.GetComponentTypeId(typeof(T4));
+            var componentType5 = ComponentTypeLookup.GetComponentTypeId(typeof(T5));
+            var componentType6 = ComponentTypeLookup.GetComponentTypeId(typeof(T6));
             
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);

--- a/src/EcsRx.Plugins.Batching/Accessors/BatchManager.cs
+++ b/src/EcsRx.Plugins.Batching/Accessors/BatchManager.cs
@@ -3,6 +3,7 @@ using EcsRx.Collections;
 using EcsRx.Components;
 using EcsRx.Components.Database;
 using EcsRx.Components.Lookups;
+using EcsRx.Extensions;
 using EcsRx.Groups.Observable;
 using EcsRx.Plugins.Batching.Factories;
 

--- a/src/EcsRx.Plugins.Batching/Accessors/BatchManager.cs
+++ b/src/EcsRx.Plugins.Batching/Accessors/BatchManager.cs
@@ -31,7 +31,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T1 : unmanaged, IComponent 
             where T2 : unmanaged, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -48,7 +48,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T1 : class, IComponent 
             where T2 : class, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -66,7 +66,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T2 : unmanaged, IComponent 
             where T3 : unmanaged, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -84,7 +84,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T2 : class, IComponent 
             where T3 : class, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -103,7 +103,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T3 : unmanaged, IComponent 
             where T4 : unmanaged, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -122,7 +122,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T3 : class, IComponent 
             where T4 : class, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -142,7 +142,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T4 : unmanaged, IComponent 
             where T5 : unmanaged, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -162,7 +162,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T4 : class, IComponent 
             where T5 : class, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -183,7 +183,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T5 : unmanaged, IComponent 
             where T6 : unmanaged, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))
@@ -204,7 +204,7 @@ namespace EcsRx.Plugins.Batching.Accessors
             where T5 : class, IComponent 
             where T6 : class, IComponent
         {
-            var componentTypes = ComponentTypeLookup.GetComponentTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6));
+            var componentTypes = ComponentTypeLookup.GetComponentTypeIds(typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6));
             var token = new AccessorToken(componentTypes, observableGroup);
             
             if (BatchAccessors.ContainsKey(token))

--- a/src/EcsRx.Plugins.Batching/Accessors/ReferenceBatchAccessor.cs
+++ b/src/EcsRx.Plugins.Batching/Accessors/ReferenceBatchAccessor.cs
@@ -24,8 +24,8 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
 
@@ -53,9 +53,9 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
             var pool3 = ComponentDatabase.GetPoolFor<T3>(componentType3);
@@ -86,10 +86,10 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
-            var componentType4 = ComponentTypeLookup.GetComponentType(typeof(T4));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
+            var componentType4 = ComponentTypeLookup.GetComponentTypeId(typeof(T4));
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
             var pool3 = ComponentDatabase.GetPoolFor<T3>(componentType3);
@@ -123,11 +123,11 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
-            var componentType4 = ComponentTypeLookup.GetComponentType(typeof(T4));
-            var componentType5 = ComponentTypeLookup.GetComponentType(typeof(T5));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
+            var componentType4 = ComponentTypeLookup.GetComponentTypeId(typeof(T4));
+            var componentType5 = ComponentTypeLookup.GetComponentTypeId(typeof(T5));
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
             var pool3 = ComponentDatabase.GetPoolFor<T3>(componentType3);
@@ -164,12 +164,12 @@ namespace EcsRx.Plugins.Batching.Accessors
 
         protected override IDisposable ReactToPools()
         {
-            var componentType1 = ComponentTypeLookup.GetComponentType(typeof(T1));
-            var componentType2 = ComponentTypeLookup.GetComponentType(typeof(T2));
-            var componentType3 = ComponentTypeLookup.GetComponentType(typeof(T3));
-            var componentType4 = ComponentTypeLookup.GetComponentType(typeof(T4));
-            var componentType5 = ComponentTypeLookup.GetComponentType(typeof(T5));
-            var componentType6 = ComponentTypeLookup.GetComponentType(typeof(T6));
+            var componentType1 = ComponentTypeLookup.GetComponentTypeId(typeof(T1));
+            var componentType2 = ComponentTypeLookup.GetComponentTypeId(typeof(T2));
+            var componentType3 = ComponentTypeLookup.GetComponentTypeId(typeof(T3));
+            var componentType4 = ComponentTypeLookup.GetComponentTypeId(typeof(T4));
+            var componentType5 = ComponentTypeLookup.GetComponentTypeId(typeof(T5));
+            var componentType6 = ComponentTypeLookup.GetComponentTypeId(typeof(T6));
             var pool1 = ComponentDatabase.GetPoolFor<T1>(componentType1);
             var pool2 = ComponentDatabase.GetPoolFor<T2>(componentType2);
             var pool3 = ComponentDatabase.GetPoolFor<T3>(componentType3);

--- a/src/EcsRx.Plugins.Batching/Builders/BatchBuilder.cs
+++ b/src/EcsRx.Plugins.Batching/Builders/BatchBuilder.cs
@@ -20,8 +20,8 @@ namespace EcsRx.Plugins.Batching.Builders
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
         }
 
         public PinnedBatch<T1, T2> Build(IReadOnlyList<IEntity> entities)
@@ -67,9 +67,9 @@ namespace EcsRx.Plugins.Batching.Builders
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
         }
 
         public PinnedBatch<T1, T2, T3> Build(IReadOnlyList<IEntity> entities)
@@ -121,10 +121,10 @@ namespace EcsRx.Plugins.Batching.Builders
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
-            _componentTypeId4 = componentTypeLookup.GetComponentType(typeof(T4));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
+            _componentTypeId4 = componentTypeLookup.GetComponentTypeId(typeof(T4));
         }
 
         public PinnedBatch<T1, T2, T3, T4> Build(IReadOnlyList<IEntity> entities)
@@ -183,11 +183,11 @@ namespace EcsRx.Plugins.Batching.Builders
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
-            _componentTypeId4 = componentTypeLookup.GetComponentType(typeof(T4));
-            _componentTypeId5 = componentTypeLookup.GetComponentType(typeof(T5));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
+            _componentTypeId4 = componentTypeLookup.GetComponentTypeId(typeof(T4));
+            _componentTypeId5 = componentTypeLookup.GetComponentTypeId(typeof(T5));
         }
 
         public PinnedBatch<T1, T2, T3, T4, T5> Build(IReadOnlyList<IEntity> entities)
@@ -252,12 +252,12 @@ namespace EcsRx.Plugins.Batching.Builders
         public BatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
-            _componentTypeId4 = componentTypeLookup.GetComponentType(typeof(T4));
-            _componentTypeId5 = componentTypeLookup.GetComponentType(typeof(T5));
-            _componentTypeId6 = componentTypeLookup.GetComponentType(typeof(T6));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
+            _componentTypeId4 = componentTypeLookup.GetComponentTypeId(typeof(T4));
+            _componentTypeId5 = componentTypeLookup.GetComponentTypeId(typeof(T5));
+            _componentTypeId6 = componentTypeLookup.GetComponentTypeId(typeof(T6));
         }
 
         public PinnedBatch<T1, T2, T3, T4, T5, T6> Build(IReadOnlyList<IEntity> entities)

--- a/src/EcsRx.Plugins.Batching/Builders/ReferenceBatchBuilder.cs
+++ b/src/EcsRx.Plugins.Batching/Builders/ReferenceBatchBuilder.cs
@@ -20,8 +20,8 @@ namespace EcsRx.Plugins.Batching.Builders
         public ReferenceBatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
         }
 
         public ReferenceBatch<T1, T2>[] Build(IReadOnlyList<IEntity> entities)
@@ -57,9 +57,9 @@ namespace EcsRx.Plugins.Batching.Builders
         public ReferenceBatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
         }
 
         public ReferenceBatch<T1, T2, T3>[] Build(IReadOnlyList<IEntity> entities)
@@ -101,10 +101,10 @@ namespace EcsRx.Plugins.Batching.Builders
         public ReferenceBatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
-            _componentTypeId4 = componentTypeLookup.GetComponentType(typeof(T4));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
+            _componentTypeId4 = componentTypeLookup.GetComponentTypeId(typeof(T4));
         }
 
         public ReferenceBatch<T1, T2, T3, T4>[] Build(IReadOnlyList<IEntity> entities)
@@ -150,11 +150,11 @@ namespace EcsRx.Plugins.Batching.Builders
         public ReferenceBatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
-            _componentTypeId4 = componentTypeLookup.GetComponentType(typeof(T4));
-            _componentTypeId5 = componentTypeLookup.GetComponentType(typeof(T5));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
+            _componentTypeId4 = componentTypeLookup.GetComponentTypeId(typeof(T4));
+            _componentTypeId5 = componentTypeLookup.GetComponentTypeId(typeof(T5));
         }
 
         public ReferenceBatch<T1, T2, T3, T4, T5>[] Build(IReadOnlyList<IEntity> entities)
@@ -204,12 +204,12 @@ namespace EcsRx.Plugins.Batching.Builders
         public ReferenceBatchBuilder(IComponentDatabase componentDatabase, IComponentTypeLookup componentTypeLookup)
         {
             ComponentDatabase = componentDatabase;
-            _componentTypeId1 = componentTypeLookup.GetComponentType(typeof(T1));
-            _componentTypeId2 = componentTypeLookup.GetComponentType(typeof(T2));
-            _componentTypeId3 = componentTypeLookup.GetComponentType(typeof(T3));
-            _componentTypeId4 = componentTypeLookup.GetComponentType(typeof(T4));
-            _componentTypeId5 = componentTypeLookup.GetComponentType(typeof(T5));
-            _componentTypeId6 = componentTypeLookup.GetComponentType(typeof(T6));
+            _componentTypeId1 = componentTypeLookup.GetComponentTypeId(typeof(T1));
+            _componentTypeId2 = componentTypeLookup.GetComponentTypeId(typeof(T2));
+            _componentTypeId3 = componentTypeLookup.GetComponentTypeId(typeof(T3));
+            _componentTypeId4 = componentTypeLookup.GetComponentTypeId(typeof(T4));
+            _componentTypeId5 = componentTypeLookup.GetComponentTypeId(typeof(T5));
+            _componentTypeId6 = componentTypeLookup.GetComponentTypeId(typeof(T6));
         }
 
         public ReferenceBatch<T1, T2, T3, T4, T5, T6>[] Build(IReadOnlyList<IEntity> entities)

--- a/src/EcsRx.Plugins.Batching/EcsRx.Plugins.Batching.csproj
+++ b/src/EcsRx.Plugins.Batching/EcsRx.Plugins.Batching.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.0.0</Version>
-        <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>EcsRx.Plugins.Batching</Title>
         <Authors>Grofit (LP)</Authors>
         <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/EcsRx.Plugins.Computeds/EcsRx.Plugins.Computeds.csproj
+++ b/src/EcsRx.Plugins.Computeds/EcsRx.Plugins.Computeds.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.0.0</Version>
-        <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>EcsRx.Plugins.Computeds</Title>
         <Authors>Grofit (LP)</Authors>
         <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SystemsRx.Plugins.Computeds" Version="5.0.19" />
+      <PackageReference Include="SystemsRx.Plugins.Computeds" Version="5.1.21" />
     </ItemGroup>
 
 </Project>

--- a/src/EcsRx.Plugins.GroupBinding/EcsRx.Plugins.GroupBinding.csproj
+++ b/src/EcsRx.Plugins.GroupBinding/EcsRx.Plugins.GroupBinding.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.0.0</Version>
-        <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>EcsRx.Plugins.GroupBinding</Title>
         <Authors>Grofit (LP)</Authors>
         <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/EcsRx.Plugins.Persistence/EcsRx.Plugins.Persistence.csproj
+++ b/src/EcsRx.Plugins.Persistence/EcsRx.Plugins.Persistence.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.0.0</Version>
-        <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>EcsRx.Plugins.Persistence</Title>
         <Authors>Grofit (LP)</Authors>
         <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/EcsRx.Plugins.ReactiveSystems/EcsRx.Plugins.ReactiveSystems.csproj
+++ b/src/EcsRx.Plugins.ReactiveSystems/EcsRx.Plugins.ReactiveSystems.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.0.0</Version>
-        <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>EcsRx.Plugins.ReactiveSystems</Title>
         <Authors>Grofit (LP)</Authors>
         <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/EcsRx.Plugins.Views/EcsRx.Plugins.Views.csproj
+++ b/src/EcsRx.Plugins.Views/EcsRx.Plugins.Views.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Version>0.0.0</Version>
-        <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Title>EcsRx.Plugins.Views</Title>
         <Authors>Grofit (LP)</Authors>
         <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/EcsRx.Tests/EcsRx/Database/ComponentDatabaseTests.cs
+++ b/src/EcsRx.Tests/EcsRx/Database/ComponentDatabaseTests.cs
@@ -23,7 +23,7 @@ namespace EcsRx.Tests.EcsRx.Database
             };
             
             var mockComponentLookup = Substitute.For<IComponentTypeLookup>();
-            mockComponentLookup.GetAllComponentTypes().Returns(fakeComponentTypes);
+            mockComponentLookup.GetComponentTypeMappings().Returns(fakeComponentTypes);
             
             var database = new ComponentDatabase(mockComponentLookup, expectedSize);           
             Assert.Equal(fakeComponentTypes.Count, database.ComponentData.Length);
@@ -34,7 +34,7 @@ namespace EcsRx.Tests.EcsRx.Database
         public void should_correctly_allocate_instance_when_adding()
         {
             var mockComponentLookup = Substitute.For<IComponentTypeLookup>();
-            mockComponentLookup.GetAllComponentTypes().Returns(new Dictionary<Type, int>
+            mockComponentLookup.GetComponentTypeMappings().Returns(new Dictionary<Type, int>
             {
                 {typeof(TestComponentOne), 0}
             });
@@ -48,7 +48,7 @@ namespace EcsRx.Tests.EcsRx.Database
         public void should_correctly_remove_instance()
         {
             var mockComponentLookup = Substitute.For<IComponentTypeLookup>();
-            mockComponentLookup.GetAllComponentTypes().Returns(new Dictionary<Type, int>
+            mockComponentLookup.GetComponentTypeMappings().Returns(new Dictionary<Type, int>
             {
                 {typeof(TestComponentOne), 0}
             });
@@ -66,7 +66,7 @@ namespace EcsRx.Tests.EcsRx.Database
         public void should_dispose_component_when_removed()
         {
             var mockComponentLookup = Substitute.For<IComponentTypeLookup>();
-            mockComponentLookup.GetAllComponentTypes().Returns(new Dictionary<Type, int>
+            mockComponentLookup.GetComponentTypeMappings().Returns(new Dictionary<Type, int>
             {
                 {typeof(TestComponentOne), 0}
             });

--- a/src/EcsRx.Tests/EcsRx/EntityTests.cs
+++ b/src/EcsRx.Tests/EcsRx/EntityTests.cs
@@ -60,9 +60,8 @@ namespace EcsRx.Tests.EcsRx
         {
             var componentDatabase = Substitute.For<IComponentDatabase>();
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
-            componentTypeLookup.AllComponentTypeIds.Returns(new int[1]);
-            componentTypeLookup.GetComponentTypeIds(Arg.Any<Type>()).Returns(new []{0});
-
+            componentTypeLookup.AllComponentTypeIds.Returns(new[]{0});
+            
             var entity = new Entity(1, componentDatabase, componentTypeLookup);
             var dummyComponent = Substitute.For<IComponent>();
 
@@ -82,6 +81,8 @@ namespace EcsRx.Tests.EcsRx
         {
             var componentDatabase = Substitute.For<IComponentDatabase>();
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
+            componentTypeLookup.AllComponentTypeIds.Returns(new[] { 0 });
+            
             var entity = new Entity(1, componentDatabase, componentTypeLookup);
             
             var beforeWasCalled = false;

--- a/src/EcsRx.Tests/EcsRx/EntityTests.cs
+++ b/src/EcsRx.Tests/EcsRx/EntityTests.cs
@@ -61,7 +61,7 @@ namespace EcsRx.Tests.EcsRx
             var componentDatabase = Substitute.For<IComponentDatabase>();
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new int[1]);
-            componentTypeLookup.GetComponentTypes(Arg.Any<Type>()).Returns(new []{0});
+            componentTypeLookup.GetComponentTypeIds(Arg.Any<Type>()).Returns(new []{0});
 
             var entity = new Entity(1, componentDatabase, componentTypeLookup);
             var dummyComponent = Substitute.For<IComponent>();

--- a/src/EcsRx.Tests/EcsRx/EntityTests.cs
+++ b/src/EcsRx.Tests/EcsRx/EntityTests.cs
@@ -19,7 +19,7 @@ namespace EcsRx.Tests.EcsRx
             var componentDatabase = Substitute.For<IComponentDatabase>();
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new []{0,1});
-            componentTypeLookup.GetComponentType(Arg.Any<Type>()).Returns(1);
+            componentTypeLookup.GetComponentTypeId(Arg.Any<Type>()).Returns(1);
             
             var entity = new Entity(1, componentDatabase, componentTypeLookup);
             var dummyComponent = Substitute.For<IComponent>();
@@ -101,8 +101,8 @@ namespace EcsRx.Tests.EcsRx
             var componentDatabase = Substitute.For<IComponentDatabase>();
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new[] {0, 1});
-            componentTypeLookup.GetComponentType(typeof(TestComponentOne)).Returns(0);
-            componentTypeLookup.GetComponentType(typeof(TestComponentTwo)).Returns(1);
+            componentTypeLookup.GetComponentTypeId(typeof(TestComponentOne)).Returns(0);
+            componentTypeLookup.GetComponentTypeId(typeof(TestComponentTwo)).Returns(1);
             
             var entity = new Entity(fakeEntityId, componentDatabase, componentTypeLookup);
             entity.InternalComponentAllocations[0] = 1;
@@ -117,8 +117,8 @@ namespace EcsRx.Tests.EcsRx
             var componentDatabase = Substitute.For<IComponentDatabase>();
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new[] {0, 1});
-            componentTypeLookup.GetComponentType(typeof(TestComponentOne)).Returns(0);
-            componentTypeLookup.GetComponentType(typeof(TestComponentTwo)).Returns(1);
+            componentTypeLookup.GetComponentTypeId(typeof(TestComponentOne)).Returns(0);
+            componentTypeLookup.GetComponentTypeId(typeof(TestComponentTwo)).Returns(1);
             
             var entity = new Entity(fakeEntityId, componentDatabase, componentTypeLookup);
             entity.InternalComponentAllocations[0] = 1;
@@ -132,8 +132,8 @@ namespace EcsRx.Tests.EcsRx
             
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new[] {0, 1});
-            componentTypeLookup.GetComponentType(typeof(TestComponentOne)).Returns(0);
-            componentTypeLookup.GetComponentType(typeof(TestComponentTwo)).Returns(1);
+            componentTypeLookup.GetComponentTypeId(typeof(TestComponentOne)).Returns(0);
+            componentTypeLookup.GetComponentTypeId(typeof(TestComponentTwo)).Returns(1);
             
             var componentDatabase = Substitute.For<IComponentDatabase>();
             
@@ -203,9 +203,9 @@ namespace EcsRx.Tests.EcsRx
             
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new[] {0, 1, 2});
-            componentTypeLookup.GetComponentType(fakeComponents[0].GetType()).Returns(0);
-            componentTypeLookup.GetComponentType(fakeComponents[1].GetType()).Returns(1);
-            componentTypeLookup.GetComponentType(fakeComponents[2].GetType()).Returns(2);
+            componentTypeLookup.GetComponentTypeId(fakeComponents[0].GetType()).Returns(0);
+            componentTypeLookup.GetComponentTypeId(fakeComponents[1].GetType()).Returns(1);
+            componentTypeLookup.GetComponentTypeId(fakeComponents[2].GetType()).Returns(2);
             
             var entity = new Entity(fakeEntityId, componentDatabase, componentTypeLookup);
             entity.AddComponents(fakeComponents);
@@ -231,9 +231,9 @@ namespace EcsRx.Tests.EcsRx
                 
             var componentTypeLookup = Substitute.For<IComponentTypeLookup>();
             componentTypeLookup.AllComponentTypeIds.Returns(new[] {0, 1, 2});
-            componentTypeLookup.GetComponentType(components[0].GetType()).Returns(0);
-            componentTypeLookup.GetComponentType(components[1].GetType()).Returns(1);
-            componentTypeLookup.GetComponentType(components[2].GetType()).Returns(2);
+            componentTypeLookup.GetComponentTypeId(components[0].GetType()).Returns(0);
+            componentTypeLookup.GetComponentTypeId(components[1].GetType()).Returns(1);
+            componentTypeLookup.GetComponentTypeId(components[2].GetType()).Returns(2);
             
             var entity = new Entity(fakeEntityId, componentDatabase, componentTypeLookup);
             entity.AddComponents(components);

--- a/src/EcsRx.Tests/Plugins/Batching/BatchAccessorTests.cs
+++ b/src/EcsRx.Tests/Plugins/Batching/BatchAccessorTests.cs
@@ -20,8 +20,8 @@ namespace EcsRx.Tests.Plugins.Batching
         public void should_populate_on_setup()
         {                      
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentOne)).Returns(0);
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentTwo)).Returns(1);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentOne)).Returns(0);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentTwo)).Returns(1);
 
             var mockComponentPool1 = Substitute.For<IComponentPool<TestStructComponentOne>>();
             mockComponentPool1.OnPoolExtending.Returns(Observable.Empty<bool>());
@@ -48,8 +48,8 @@ namespace EcsRx.Tests.Plugins.Batching
         public void should_update_when_observable_group_changes()
         {
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentOne)).Returns(0);
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentTwo)).Returns(1);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentOne)).Returns(0);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentTwo)).Returns(1);
 
             var mockComponentPool1 = Substitute.For<IComponentPool<TestStructComponentOne>>();
             mockComponentPool1.OnPoolExtending.Returns(Observable.Empty<bool>());
@@ -81,8 +81,8 @@ namespace EcsRx.Tests.Plugins.Batching
         public void should_update_when_component_pool_changes()
         {
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentOne)).Returns(0);
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentTwo)).Returns(1);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentOne)).Returns(0);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentTwo)).Returns(1);
 
             var poolChanging1Subject = new Subject<bool>();
             var mockComponentPool1 = Substitute.For<IComponentPool<TestStructComponentOne>>();

--- a/src/EcsRx.Tests/Plugins/Batching/BatchBuilderTests.cs
+++ b/src/EcsRx.Tests/Plugins/Batching/BatchBuilderTests.cs
@@ -26,8 +26,8 @@ namespace EcsRx.Tests.Plugins.Batching
             mockComponentDatabase.GetComponents<TestStructComponentTwo>(Arg.Any<int>()).Returns(fakeTwos);
             
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentOne)).Returns(0);
-            mockTypeLookup.GetComponentType(typeof(TestStructComponentTwo)).Returns(1);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentOne)).Returns(0);
+            mockTypeLookup.GetComponentTypeId(typeof(TestStructComponentTwo)).Returns(1);
 
             var fakeEntity1 = Substitute.For<IEntity>();
             fakeEntity1.Id.Returns(1);

--- a/src/EcsRx.Tests/Plugins/Batching/ReferenceBatchBuilderTests.cs
+++ b/src/EcsRx.Tests/Plugins/Batching/ReferenceBatchBuilderTests.cs
@@ -26,8 +26,8 @@ namespace EcsRx.Tests.Plugins.Batching
             mockComponentDatabase.GetComponents<TestComponentTwo>(Arg.Any<int>()).Returns(fakeTwos);
             
             var mockTypeLookup = Substitute.For<IComponentTypeLookup>();
-            mockTypeLookup.GetComponentType(typeof(TestComponentOne)).Returns(0);
-            mockTypeLookup.GetComponentType(typeof(TestComponentTwo)).Returns(1);
+            mockTypeLookup.GetComponentTypeId(typeof(TestComponentOne)).Returns(0);
+            mockTypeLookup.GetComponentTypeId(typeof(TestComponentTwo)).Returns(1);
 
             var fakeEntity1 = Substitute.For<IEntity>();
             fakeEntity1.Id.Returns(1);

--- a/src/EcsRx.Tests/Sanity/SanityTests.cs
+++ b/src/EcsRx.Tests/Sanity/SanityTests.cs
@@ -288,10 +288,10 @@ namespace EcsRx.Tests.Sanity
             Assert.Equal(expectedSize, collection.Count);
             Assert.Equal(expectedSize, observableGroup.Count);
 
-            var viewComponentPool = componentDatabase.GetPoolFor<ViewComponent>(componentLookup.GetComponentType(typeof(ViewComponent)));
+            var viewComponentPool = componentDatabase.GetPoolFor<ViewComponent>(componentLookup.GetComponentTypeId(typeof(ViewComponent)));
             Assert.Equal(expectedSize, viewComponentPool.Components.Length);
             
-            var testComponentPool = componentDatabase.GetPoolFor<TestComponentOne>(componentLookup.GetComponentType(typeof(TestComponentOne)));
+            var testComponentPool = componentDatabase.GetPoolFor<TestComponentOne>(componentLookup.GetComponentTypeId(typeof(TestComponentOne)));
             Assert.Equal(expectedSize, testComponentPool.Components.Length);
         }
     }

--- a/src/EcsRx/Collections/ObservableGroupManager.cs
+++ b/src/EcsRx/Collections/ObservableGroupManager.cs
@@ -40,8 +40,8 @@ namespace EcsRx.Collections
 
         public IObservableGroup GetObservableGroup(IGroup group, params int[] collectionIds)
         {
-            var requiredComponents = ComponentTypeLookup.GetComponentTypes(group.RequiredComponents);
-            var excludedComponents = ComponentTypeLookup.GetComponentTypes(group.ExcludedComponents);
+            var requiredComponents = ComponentTypeLookup.GetComponentTypeIds(group.RequiredComponents);
+            var excludedComponents = ComponentTypeLookup.GetComponentTypeIds(group.ExcludedComponents);
             var lookupGroup = new LookupGroup(requiredComponents, excludedComponents);
             
             var observableGroupToken = new ObservableGroupToken(lookupGroup, collectionIds);

--- a/src/EcsRx/Components/Accessor/ComponentAccessor.cs
+++ b/src/EcsRx/Components/Accessor/ComponentAccessor.cs
@@ -1,0 +1,29 @@
+﻿using EcsRx.Entities;
+using EcsRx.Extensions;
+
+namespace EcsRx.Components.Accessor
+{
+    public class ComponentAccessor<T> : IComponentAccessor<T>
+    {
+        public int ComponentTypeId { get; }
+
+        public ComponentAccessor(int componentTypeTypeId)
+        { ComponentTypeId = componentTypeTypeId; }
+
+        public bool Has(IEntity entity) => entity.HasComponent(ComponentTypeId);
+        public T Get(IEntity entity) => (T)entity.GetComponent(ComponentTypeId);
+        public void Remove(IEntity entity) => entity.RemoveComponents(ComponentTypeId);
+        
+        public bool TryGet(IEntity entity, out T component)
+        {
+            if (Has(entity))
+            {
+                component = Get(entity);
+                return true;
+            }
+
+            component = default;
+            return false;
+        }
+    }
+}

--- a/src/EcsRx/Components/Accessor/IComponentAccessor.cs
+++ b/src/EcsRx/Components/Accessor/IComponentAccessor.cs
@@ -1,0 +1,22 @@
+﻿using EcsRx.Entities;
+
+namespace EcsRx.Components.Accessor
+{
+    /// <summary>
+    /// Represents an optimised way to interact with a component type on an entity
+    /// </summary>
+    /// <typeparam name="T">The type of the component</typeparam>
+    /// <remarks>
+    /// In most cases you can just use the provided extension methods on IEntity, however for
+    /// optimisations purposes this provides you a streamlined way to caching the component
+    /// type id and relaying calls through to the underlying entity.
+    /// </remarks>
+    public interface IComponentAccessor<T>
+    {
+        int ComponentTypeId { get; }
+        bool Has(IEntity entity);
+        T Get(IEntity entity);
+        bool TryGet(IEntity entity, out T component);
+        void Remove(IEntity entity);
+    }
+}

--- a/src/EcsRx/Components/Database/ComponentDatabase.cs
+++ b/src/EcsRx/Components/Database/ComponentDatabase.cs
@@ -29,7 +29,7 @@ namespace EcsRx.Components.Database
         
         public void Initialize()
         {
-            var componentTypes = ComponentTypeLookup.GetAllComponentTypes().ToArray();
+            var componentTypes = ComponentTypeLookup.GetComponentTypeMappings().ToArray();
             var componentCount = componentTypes.Length;
             ComponentData = new IComponentPool[componentCount];
 

--- a/src/EcsRx/Components/Lookups/ComponentTypeLookup.cs
+++ b/src/EcsRx/Components/Lookups/ComponentTypeLookup.cs
@@ -27,17 +27,11 @@ namespace EcsRx.Components.Lookups
                 .ToArray();
         }
 
-        public int GetComponentType<T>() where T : IComponent
-        { return GetComponentType(typeof(T)); }
-
-        public int GetComponentType(Type type)
+        public int GetComponentTypeId(Type type)
         { return ComponentsByType[type]; }
-        
-        public int[] GetComponentTypes(params Type[] types)
-        { return types.Select(GetComponentType).ToArray(); }
 
-        public Type[] GetComponentTypes(params int[] typeIds)
-        { return typeIds.Select(x => ComponentsById[x]).ToArray(); }
+        public Type GetComponentType(int typeId)
+        { return ComponentsById[typeId]; }
 
         public bool IsComponentStruct(int componentTypeId)
         { return ComponentStructLookups[componentTypeId]; }
@@ -45,10 +39,7 @@ namespace EcsRx.Components.Lookups
         public bool IsComponentDisposable(int componentTypeId)
         { return ComponentDisposableLookups[componentTypeId]; }
 
-        public T CreateDefault<T>() where T : IComponent, new()
-        { return new T(); }
-
-        public IReadOnlyDictionary<Type, int> GetAllComponentTypes()
+        public IReadOnlyDictionary<Type, int> GetComponentTypeMappings()
         { return ComponentsByType; }
     }
 }

--- a/src/EcsRx/Components/Lookups/DefaultComponentTypeAssigner.cs
+++ b/src/EcsRx/Components/Lookups/DefaultComponentTypeAssigner.cs
@@ -6,7 +6,7 @@ namespace EcsRx.Components.Lookups
 {
     public class DefaultComponentTypeAssigner : IComponentTypeAssigner
     {
-        private IEnumerable<Type> GetAllComponentTypes()
+        public IEnumerable<Type> GetAllComponentTypes()
         {
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             var componentType = typeof(IComponent);
@@ -19,8 +19,7 @@ namespace EcsRx.Components.Lookups
         public IReadOnlyDictionary<Type, int> GenerateComponentLookups()
         {
             var lookupId = 0;
-            var componentTypes = GetAllComponentTypes();
-            return componentTypes.ToDictionary(x => x, _ => lookupId++);
+            return GetAllComponentTypes()?.ToDictionary(x => x, _ => lookupId++);
         }
     }
 }

--- a/src/EcsRx/Components/Lookups/IComponentTypeAssigner.cs
+++ b/src/EcsRx/Components/Lookups/IComponentTypeAssigner.cs
@@ -3,6 +3,15 @@ using System.Collections.Generic;
 
 namespace EcsRx.Components.Lookups
 {
+    /// <summary>
+    /// The Component Type Assigner interface is used to generate the internal lookup mappings
+    /// for component types to ids.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation provided in this framework will use reflection to find all
+    /// IComponent implementations within the AppDomain and then register them arbitrary values
+    /// so this may not be consistent between runs.
+    /// </remarks>
     public interface IComponentTypeAssigner
     {
         IReadOnlyDictionary<Type, int> GenerateComponentLookups();

--- a/src/EcsRx/Components/Lookups/IComponentTypeLookup.cs
+++ b/src/EcsRx/Components/Lookups/IComponentTypeLookup.cs
@@ -3,17 +3,17 @@ using System.Collections.Generic;
 
 namespace EcsRx.Components.Lookups
 {
+    /// <summary>
+    /// The Component Type Lookup interface is responsible for looking up
+    /// component ids for the types as well as vice versa. 
+    /// </summary>
     public interface IComponentTypeLookup
     {
         int[] AllComponentTypeIds { get; }
-
-        IReadOnlyDictionary<Type, int> GetAllComponentTypes();
-        int GetComponentType<T>() where T : IComponent;
-        int GetComponentType(Type type);
-        int[] GetComponentTypes(params Type[] types);
-        Type[] GetComponentTypes(params int[] typeIds);
+        IReadOnlyDictionary<Type, int> GetComponentTypeMappings();
+        int GetComponentTypeId(Type type);
+        Type GetComponentType(int typeId);
         bool IsComponentStruct(int componentTypeId);
         bool IsComponentDisposable(int componentTypeId);
-        T CreateDefault<T>() where T : IComponent, new();
     }
 }

--- a/src/EcsRx/EcsRx.csproj
+++ b/src/EcsRx/EcsRx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>0.0.0</Version>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>EcsRx</Title>
     <Authors>Grofit (LP)</Authors>
     <PackageLicenseUrl>https://github.com/ecsrx/ecsrx/blob/master/LICENSE</PackageLicenseUrl>
@@ -20,7 +20,7 @@
     <None Remove="Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SystemsRx" Version="5.0.19" />
-    <PackageReference Include="SystemsRx.MicroRx" Version="5.0.19" />
+    <PackageReference Include="SystemsRx" Version="5.1.21" />
+    <PackageReference Include="SystemsRx.MicroRx" Version="5.1.21" />
   </ItemGroup>
 </Project>

--- a/src/EcsRx/Entities/Entity.cs
+++ b/src/EcsRx/Entities/Entity.cs
@@ -68,7 +68,7 @@ namespace EcsRx.Entities
             var componentTypeIds = new int[components.Count];
             for (var i = 0; i < components.Count; i++)
             {
-                var componentTypeId = ComponentTypeLookup.GetComponentType(components[i].GetType());
+                var componentTypeId = ComponentTypeLookup.GetComponentTypeId(components[i].GetType());
                 var allocationId = ComponentDatabase.Allocate(componentTypeId);
                 InternalComponentAllocations[componentTypeId] = allocationId;
                 ComponentDatabase.Set(componentTypeId, allocationId, components[i]);
@@ -125,7 +125,7 @@ namespace EcsRx.Entities
 
         public bool HasComponent(Type componentType)
         {
-            var componentTypeId = ComponentTypeLookup.GetComponentType(componentType);
+            var componentTypeId = ComponentTypeLookup.GetComponentTypeId(componentType);
             return HasComponent(componentTypeId);
         }
 
@@ -134,7 +134,7 @@ namespace EcsRx.Entities
 
         public IComponent GetComponent(Type componentType)
         {
-            var componentTypeId = ComponentTypeLookup.GetComponentType(componentType);
+            var componentTypeId = ComponentTypeLookup.GetComponentTypeId(componentType);
             return GetComponent(componentTypeId);
         }
 

--- a/src/EcsRx/Entities/Entity.cs
+++ b/src/EcsRx/Entities/Entity.cs
@@ -98,7 +98,7 @@ namespace EcsRx.Entities
         
         public void RemoveComponents(params Type[] componentTypes)
         {
-            var componentTypeIds = ComponentTypeLookup.GetComponentTypes(componentTypes);
+            var componentTypeIds = ComponentTypeLookup.GetComponentTypeIds(componentTypes);
             RemoveComponents(componentTypeIds);
         }
         

--- a/src/EcsRx/Extensions/IComponentAccessorExtensions.cs
+++ b/src/EcsRx/Extensions/IComponentAccessorExtensions.cs
@@ -1,0 +1,12 @@
+﻿using EcsRx.Components;
+using EcsRx.Components.Accessor;
+using EcsRx.Entities;
+
+namespace EcsRx.Extensions
+{
+    public static class IComponentAccessorExtensions
+    {
+        public static ref T Add<T>(this IComponentAccessor<T> accessor, IEntity entity)
+            where T : IComponent, new() => ref entity.AddComponent<T>(accessor.ComponentTypeId);
+    }
+}

--- a/src/EcsRx/Extensions/IComponentTypeLookupExtensions.cs
+++ b/src/EcsRx/Extensions/IComponentTypeLookupExtensions.cs
@@ -15,7 +15,7 @@ namespace EcsRx.Extensions
         public static T CreateDefault<T>(this IComponentTypeLookup typeLookup) where T : IComponent, new()
         { return new T(); }
         
-        public static int[] GetComponentTypes(this IComponentTypeLookup typeLookup, params Type[] types)
+        public static int[] GetComponentTypeIds(this IComponentTypeLookup typeLookup, params Type[] types)
         { return types.Select(typeLookup.GetComponentTypeId).ToArray(); }
 
         public static Type[] GetComponentTypes(this IComponentTypeLookup typeLookup, params int[] typeIds)

--- a/src/EcsRx/Extensions/IComponentTypeLookupExtensions.cs
+++ b/src/EcsRx/Extensions/IComponentTypeLookupExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using EcsRx.Components;
+using EcsRx.Components.Accessor;
 using EcsRx.Components.Lookups;
 
 namespace EcsRx.Extensions
@@ -25,5 +26,11 @@ namespace EcsRx.Extensions
 
         public static Type[] GetComponentTypes(this IComponentTypeLookup typeLookup, IEnumerable<int> typeIds)
         { return typeIds.Select(typeLookup.GetComponentType).ToArray(); }
+
+        public static IComponentAccessor<T> GetAccessorFor<T>(this IComponentTypeLookup typeLookup)
+        {
+            var componentTypeId = typeLookup.GetComponentTypeId(typeof(T));
+            return new ComponentAccessor<T>(componentTypeId);
+        }
     }
 }

--- a/src/EcsRx/Extensions/IComponentTypeLookupExtensions.cs
+++ b/src/EcsRx/Extensions/IComponentTypeLookupExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EcsRx.Components;
+using EcsRx.Components.Lookups;
+
+namespace EcsRx.Extensions
+{
+    public static class IComponentTypeLookupExtensions
+    {
+        public static int GetComponentType<T>(this IComponentTypeLookup typeLookup) where T : IComponent
+        { return typeLookup.GetComponentTypeId(typeof(T)); }
+        
+        public static T CreateDefault<T>(this IComponentTypeLookup typeLookup) where T : IComponent, new()
+        { return new T(); }
+        
+        public static int[] GetComponentTypes(this IComponentTypeLookup typeLookup, params Type[] types)
+        { return types.Select(typeLookup.GetComponentTypeId).ToArray(); }
+
+        public static Type[] GetComponentTypes(this IComponentTypeLookup typeLookup, params int[] typeIds)
+        { return typeIds.Select(typeLookup.GetComponentType).ToArray(); }
+        
+        public static int[] GetComponentTypes(this IComponentTypeLookup typeLookup, IEnumerable<Type> types)
+        { return types.Select(typeLookup.GetComponentTypeId).ToArray(); }
+
+        public static Type[] GetComponentTypes(this IComponentTypeLookup typeLookup, IEnumerable<int> typeIds)
+        { return typeIds.Select(typeLookup.GetComponentType).ToArray(); }
+    }
+}


### PR DESCRIPTION
Thanks to @thejayman for pointing out that there was a common scenario where people want to be able to get components from entities in an efficient manner but only have the type available.

While you can manually do the lookup to get the type id and cache it the `IComponentAccessor` notion provides a streamlined way to do this.

An extension method has been made on the back of the `IComponentTypeLookup` however you can new them up however you want or implement your own version of it.

This PR also removes explicit support for .net 4.6 in favour of a simpler single target of netstandard2.0 