### PR TITLE
Entity AddComponent type constaint fix and Group.Empty promotion

### DIFF
--- a/src/EcsRx.Tests/EcsRx/Handlers/BasicEntitySystemHandlerTests.cs
+++ b/src/EcsRx.Tests/EcsRx/Handlers/BasicEntitySystemHandlerTests.cs
@@ -56,7 +56,7 @@ namespace EcsRx.Tests.EcsRx.Handlers
             var observableSubject = new Subject<ElapsedTime>();
             observableScheduler.OnUpdate.Returns(observableSubject);
             
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var mockSystem = Substitute.For<IBasicEntitySystem>();

--- a/src/EcsRx.Tests/Plugins/ReactiveSystems/Handlers/ReactToDataSystemHandlerTests.cs
+++ b/src/EcsRx.Tests/Plugins/ReactiveSystems/Handlers/ReactToDataSystemHandlerTests.cs
@@ -51,7 +51,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var firstEntitySubject = new Subject<int>();
@@ -100,7 +100,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var firstEntitySubject = new Subject<int>();
@@ -160,7 +160,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var firstEntitySubject = new Subject<int>();

--- a/src/EcsRx.Tests/Plugins/ReactiveSystems/Handlers/ReactToEntitySystemHandlerTests.cs
+++ b/src/EcsRx.Tests/Plugins/ReactiveSystems/Handlers/ReactToEntitySystemHandlerTests.cs
@@ -49,7 +49,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var firstEntitySubject = new Subject<IEntity>();
@@ -98,7 +98,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var firstEntitySubject = new Subject<IEntity>();
@@ -158,7 +158,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var firstEntitySubject = new Subject<IEntity>();

--- a/src/EcsRx.Tests/Plugins/ReactiveSystems/Handlers/ReactToGroupSystemHandlerTests.cs
+++ b/src/EcsRx.Tests/Plugins/ReactiveSystems/Handlers/ReactToGroupSystemHandlerTests.cs
@@ -51,7 +51,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
             var threadHandler = Substitute.For<IThreadHandler>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var observableSubject = new Subject<IObservableGroup>();
@@ -87,7 +87,7 @@ namespace EcsRx.Tests.Plugins.ReactiveSystems.Handlers
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
             var threadHandler = Substitute.For<IThreadHandler>();
 
-            var fakeGroup = new Group();
+            var fakeGroup = Group.Empty;
             observableGroupManager.GetObservableGroup(Arg.Is(fakeGroup), Arg.Any<int[]>()).Returns(mockObservableGroup);
 
             var observableSubject = new Subject<IObservableGroup>();

--- a/src/EcsRx.Tests/Systems/ReactiveDataTestSystem.cs
+++ b/src/EcsRx.Tests/Systems/ReactiveDataTestSystem.cs
@@ -19,7 +19,7 @@ namespace EcsRx.Tests.Systems
 
         public void Process(IEntity entity, float reactionData)
         {
-            throw new System.NotImplementedException();
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/EcsRx/Extensions/IEntityExtensions.cs
+++ b/src/EcsRx/Extensions/IEntityExtensions.cs
@@ -51,7 +51,7 @@ namespace EcsRx.Extensions
         /// <param name="entity">entity to use</param>
         /// <param name="component">The component to add</param>
         /// <returns>The created component</returns>
-        public static T AddComponent<T>(this IEntity entity, T component) where T : class, IComponent, new()
+        public static T AddComponent<T>(this IEntity entity, T component) where T : class, IComponent
         {
             entity.AddComponents(component);
             return component;

--- a/src/EcsRx/Groups/Group.cs
+++ b/src/EcsRx/Groups/Group.cs
@@ -6,9 +6,16 @@ namespace EcsRx.Groups
 {
     public class Group : IGroup
     {
-        public Type[] RequiredComponents { get; }
+		public static readonly IGroup Empty = new EmptyGroup();
+
+		public Type[] RequiredComponents { get; }
 	    public Type[] ExcludedComponents { get; }
-        
+
+		/// <summary>
+		/// Hint: maybe consider using Group.Empty for better performance, unless you plan on changing the group afterwards.
+		/// </summary>
+		public Group() {}
+
 		public Group(params Type[] requiredComponents) : this(requiredComponents, Array.Empty<Type>()) {}
         
 	    public Group(IEnumerable<Type> requiredComponents, IEnumerable<Type> excludedComponents)


### PR DESCRIPTION
I just found out why I often can't use the IEntity.AddComponent extension with the overload where you can pass in the instance of the component to be added.
I used to just fall back to using the IEntity.AddComponents extension method (which uses params) but today I fixed the issue with the other one.
Note that the new() constraint makes sense for the other overload there's no component instance passed in there. Hence why I assume this was a copy paste oversight.

I also included some minor changes promoting the use of EmptyGroup and adding a static singleton for that on Group.