### PR TITLE
fix: entity disposal when an observable group is created late

### DIFF
--- a/src/EcsRx.Tests/Sanity/SanityTests.cs
+++ b/src/EcsRx.Tests/Sanity/SanityTests.cs
@@ -85,21 +85,18 @@ namespace EcsRx.Tests.Sanity
         }
 
         [Fact]
-        public void test()
+        public void entity_disposal_works_when_using_late_initialized_observable_groups_without_matches()
         {
             var (observableGroupManager, entityDatabase, _, _) = CreateFramework();
-            var test = observableGroupManager.GetObservableGroup(new Group(typeof(TestComponentOne)));
-            var test2 = observableGroupManager.GetObservableGroup(new Group(typeof(TestComponentOne), typeof(TestComponentTwo)));
-            test.OnEntityRemoving.Subscribe(_ => { });
-            test.OnEntityRemoved.Subscribe(_ => { });
-            test2.OnEntityRemoving.Subscribe(_ => { });
-            test2.OnEntityRemoved.Subscribe(_ => { });
 
             var collection = entityDatabase.GetCollection();
             var entityOne = collection.CreateEntity();
-            entityOne.AddComponents(new TestComponentOne(), new TestComponentTwo());
+            entityOne.AddComponents(new TestComponentOne(), new TestComponentThree());
 
-            entityOne.Dispose();
+            // note, that this behaves differently for entities present before it is called.
+            _ = observableGroupManager.GetObservableGroup(new Group(typeof(TestComponentOne), typeof(TestComponentTwo)));
+
+            entityOne.Dispose(); // just asseting this doesn't throw an exception
         }
 
         [Fact]

--- a/src/EcsRx.Tests/Sanity/SanityTests.cs
+++ b/src/EcsRx.Tests/Sanity/SanityTests.cs
@@ -60,7 +60,7 @@ namespace EcsRx.Tests.Sanity
 
             return (observableGroupManager, entityDatabase, componentDatabase, componentLookupType);
         }
-        
+
         private SystemExecutor CreateExecutor(IObservableGroupManager observableGroupManager)
         {
             var threadHandler = new DefaultThreadHandler();
@@ -80,8 +80,26 @@ namespace EcsRx.Tests.Sanity
                 manualSystemHandler,
                 teardownHandler
             };
-            
+
             return new SystemExecutor(conventionalSystems);
+        }
+
+        [Fact]
+        public void test()
+        {
+            var (observableGroupManager, entityDatabase, _, _) = CreateFramework();
+            var test = observableGroupManager.GetObservableGroup(new Group(typeof(TestComponentOne)));
+            var test2 = observableGroupManager.GetObservableGroup(new Group(typeof(TestComponentOne), typeof(TestComponentTwo)));
+            test.OnEntityRemoving.Subscribe(_ => { });
+            test.OnEntityRemoved.Subscribe(_ => { });
+            test2.OnEntityRemoving.Subscribe(_ => { });
+            test2.OnEntityRemoved.Subscribe(_ => { });
+
+            var collection = entityDatabase.GetCollection();
+            var entityOne = collection.CreateEntity();
+            entityOne.AddComponents(new TestComponentOne(), new TestComponentTwo());
+
+            entityOne.Dispose();
         }
 
         [Fact]
@@ -101,7 +119,7 @@ namespace EcsRx.Tests.Sanity
             Assert.Equal("woop", entityOne.GetComponent<TestComponentOne>().Data);
             Assert.Null(entityTwo.GetComponent<TestComponentTwo>().Data);
         }
-        
+
         [Fact]
         public void should_not_freak_out_when_removing_components_during_removing_event()
         {
@@ -118,23 +136,23 @@ namespace EcsRx.Tests.Sanity
 
             entityOne.AddComponents(new TestComponentOne(), new TestComponentTwo());
             entityOne.RemoveComponent<TestComponentOne>();
-            
+
             Assert.Equal(2, timesCalled);
         }
-        
+
         [Fact]
         public void should_treat_view_handler_as_setup_system_and_teardown_system()
         {
             var observableGroupManager = Substitute.For<IObservableGroupManager>();
             var setupSystemHandler = new SetupSystemHandler(observableGroupManager);
             var teardownSystemHandler = new TeardownSystemHandler(observableGroupManager);
-            
+
             var viewSystem = Substitute.For<IViewResolverSystem>();
-            
+
             Assert.True(setupSystemHandler.CanHandleSystem(viewSystem));
             Assert.True(teardownSystemHandler.CanHandleSystem(viewSystem));
         }
-        
+
         [Fact]
         public void should_trigger_both_setup_and_teardown_for_view_resolver()
         {
@@ -148,22 +166,22 @@ namespace EcsRx.Tests.Sanity
             viewResolverSystem.OnSetup = entity => { setupCalled = true; };
             var teardownCalled = false;
             viewResolverSystem.OnTeardown = entity => { teardownCalled = true; };
-            
+
             var collection = entityDatabase.GetCollection();
             var entityOne = collection.CreateEntity();
             entityOne.AddComponents(new TestComponentOne(), new ViewComponent());
 
             collection.RemoveEntity(entityOne.Id);
-            
+
             Assert.True(setupCalled);
             Assert.True(teardownCalled);
         }
-        
+
         [Fact]
         public void should_listen_to_multiple_collections_for_updates()
         {
             var (observableGroupManager, entityDatabase, _, _) = CreateFramework();
-            
+
             var group = new Group(typeof(TestComponentOne));
             var collection1 = entityDatabase.CreateCollection(1);
             var collection2 = entityDatabase.CreateCollection(2);
@@ -181,18 +199,18 @@ namespace EcsRx.Tests.Sanity
 
             var entity2 = collection2.CreateEntity();
             entity2.AddComponent<TestComponentOne>();
-            
+
             collection1.RemoveEntity(entity1.Id);
             collection2.RemoveEntity(entity2.Id);
-            
+
             Assert.Equal(2, addedTimesCalled);
             Assert.Equal(2, removingTimesCalled);
             Assert.Equal(2, removedTimesCalled);
         }
-        
+
         [Fact]
         public unsafe void should_keep_state_with_batches()
-        {            
+        {
             var (_, entityDatabase, componentDatabase, componentLookup) = CreateFramework();
             var collection1 = entityDatabase.CreateCollection(1);
             var entity1 = collection1.CreateEntity();
@@ -205,7 +223,7 @@ namespace EcsRx.Tests.Sanity
             ref var structComponent1 = ref entity1.AddComponent<TestStructComponentOne>(4);
             var component1Allocation = entity1.ComponentAllocations[4];
             structComponent1.Data = startingInt;
-            
+
             ref var structComponent2 = ref entity1.AddComponent<TestStructComponentTwo>(5);
             var component2Allocation = entity1.ComponentAllocations[5];
             structComponent2.Data = startingFloat;
@@ -213,27 +231,27 @@ namespace EcsRx.Tests.Sanity
             var entities = new[] {entity1};
             var batchBuilder = new BatchBuilder<TestStructComponentOne, TestStructComponentTwo>(componentDatabase, componentLookup);
             var batch = batchBuilder.Build(entities);
-            
+
             ref var initialBatchData = ref batch.Batches[0];
             ref var component1 = ref *initialBatchData.Component1;
             ref var component2 = ref *initialBatchData.Component2;
             Assert.Equal(startingInt, component1.Data);
             Assert.Equal(startingFloat, component2.Data);
-            
+
             component1.Data = finalInt;
             component2.Data = finalFloat;
-            
+
             Assert.Equal(finalInt, (*batch.Batches[0].Component1).Data);
             Assert.Equal(finalInt, structComponent1.Data);
             Assert.Equal(finalInt, componentDatabase.Get<TestStructComponentOne>(4, component1Allocation).Data);
             Assert.Equal(finalFloat, (*batch.Batches[0].Component2).Data);
             Assert.Equal(finalFloat, structComponent2.Data);
-            Assert.Equal(finalFloat, componentDatabase.Get<TestStructComponentTwo>(5, component2Allocation).Data);        
+            Assert.Equal(finalFloat, componentDatabase.Get<TestStructComponentTwo>(5, component2Allocation).Data);
         }
-        
+
         [Fact]
         public unsafe void should_retain_pointer_through_new_struct()
-        {            
+        {
             var (_, entityDatabase, componentDatabase, componentLookup) = CreateFramework();
             var collection1 = entityDatabase.CreateCollection(1);
             var entity1 = collection1.CreateEntity();
@@ -246,7 +264,7 @@ namespace EcsRx.Tests.Sanity
             ref var structComponent1 = ref entity1.AddComponent<TestStructComponentOne>(4);
             var component1Allocation = entity1.ComponentAllocations[4];
             structComponent1.Data = startingInt;
-            
+
             ref var structComponent2 = ref entity1.AddComponent<TestStructComponentTwo>(5);
             var component2Allocation = entity1.ComponentAllocations[5];
             structComponent2.Data = startingFloat;
@@ -254,14 +272,14 @@ namespace EcsRx.Tests.Sanity
             var entities = new[] {entity1};
             var batchBuilder = new BatchBuilder<TestStructComponentOne, TestStructComponentTwo>(componentDatabase, componentLookup);
             var batch = batchBuilder.Build(entities);
-            
+
             ref var initialBatchData = ref batch.Batches[0];
             ref var component1 = ref *initialBatchData.Component1;
             ref var component2 = ref *initialBatchData.Component2;
 
             Assert.Equal(startingInt, component1.Data);
             Assert.Equal(startingFloat, component2.Data);
-            
+
             component1 = new TestStructComponentOne {Data = finalInt};
             component2 = new TestStructComponentTwo {Data = finalFloat};
 
@@ -270,9 +288,9 @@ namespace EcsRx.Tests.Sanity
             Assert.Equal(finalInt, componentDatabase.Get<TestStructComponentOne>(4, component1Allocation).Data);
             Assert.Equal(finalFloat, (*batch.Batches[0].Component2).Data);
             Assert.Equal(finalFloat, structComponent2.Data);
-            Assert.Equal(finalFloat, componentDatabase.Get<TestStructComponentTwo>(5, component2Allocation).Data);        
+            Assert.Equal(finalFloat, componentDatabase.Get<TestStructComponentTwo>(5, component2Allocation).Data);
         }
-        
+
         [Fact]
         public void should_allocate_entities_correctly()
         {
@@ -280,7 +298,7 @@ namespace EcsRx.Tests.Sanity
             var (observableGroupManager, entityDatabase, componentDatabase, componentLookup) = CreateFramework();
             var collection = entityDatabase.GetCollection();
             var observableGroup = observableGroupManager.GetObservableGroup(new Group(typeof(ViewComponent), typeof(TestComponentOne)));
-            
+
             for (var i = 0; i < expectedSize; i++)
             {
                 var entity = collection.CreateEntity();
@@ -292,7 +310,7 @@ namespace EcsRx.Tests.Sanity
 
             var viewComponentPool = componentDatabase.GetPoolFor<ViewComponent>(componentLookup.GetComponentTypeId(typeof(ViewComponent)));
             Assert.Equal(expectedSize, viewComponentPool.Components.Length);
-            
+
             var testComponentPool = componentDatabase.GetPoolFor<TestComponentOne>(componentLookup.GetComponentTypeId(typeof(TestComponentOne)));
             Assert.Equal(expectedSize, testComponentPool.Components.Length);
         }

--- a/src/EcsRx/Collections/ObservableGroupManager.cs
+++ b/src/EcsRx/Collections/ObservableGroupManager.cs
@@ -46,22 +46,27 @@ namespace EcsRx.Collections
             if (_observableGroups.Contains(observableGroupToken)) 
             { return _observableGroups[observableGroupToken]; }
 
-            var entityMatches = EntityDatabase.GetEntitiesFor(lookupGroup, collectionIds);
             var configuration = new ObservableGroupConfiguration
             {
-                ObservableGroupToken = observableGroupToken,
-                InitialEntities = entityMatches
+                ObservableGroupToken = observableGroupToken
             };
 
             if (collectionIds != null && collectionIds.Length > 0)
-            { configuration.NotifyingCollections = EntityDatabase.Collections.Where(x => collectionIds.Contains(x.Id)); }
+            {
+                var targetedCollections = EntityDatabase.Collections.Where(x => collectionIds.Contains(x.Id));
+                configuration.NotifyingCollections = targetedCollections;
+                configuration.InitialEntities = targetedCollections.GetAllEntities();
+            }
             else
-            { configuration.NotifyingCollections = new []{EntityDatabase}; }
+            {
+                configuration.NotifyingCollections = new[] { EntityDatabase };
+                configuration.InitialEntities = EntityDatabase.Collections.GetAllEntities();
+            }
             
             var observableGroup = ObservableGroupFactory.Create(configuration);
             _observableGroups.Add(observableGroup);
 
-            return _observableGroups[observableGroupToken];
+            return observableGroup;
         }
 
         public void Dispose()


### PR DESCRIPTION
This was one of the issues I was encountering with my game after updating from EcsRx 5.0.110 to 6.0.131.
Executing dispose on an entity was leading causing an **KeyNotFoundException** in _CollectionObservableGroupTracker.GetState(int entityId)_.

I was eventually able to narrow the issue down to the fact that certain _ObservableGroups_ were created after some of the entities they would end up watching were already present.
It turns out there was a discrepancy between what the _CollectionObservableGroupTracker_ was expecting from the constructor parameter _initialEntities_ and what it was being provided with.

In contrast to the previously it was expecting all entities of the targeted entity collections.
However it was only provided with already matching entities, which lead to it trying to later access the state of some entities which weren't matching but should have been present in _EntityIdMatchTypes_ as _GroupMatchingType.NoMatchesNoExcludes_ or something similar.

As this issue requires different services to work together it ended up adding an integration test to detect that issue. I also made the required changes so that test ends up passing now.

Sorry for the noise due to my trailing whitespace removal plugin. Let me know if it bugs you and I can get rid of it.