### PR TITLE
fix: Group ending up with null members

### DIFF
--- a/src/EcsRx/Groups/Group.cs
+++ b/src/EcsRx/Groups/Group.cs
@@ -21,9 +21,7 @@ namespace EcsRx.Groups
 
 		public Group(params Type[] requiredComponents) {
             if (requiredComponents is null)
-            {
-                throw new ArgumentNullException(nameof(requiredComponents));
-            }
+            { throw new ArgumentNullException(nameof(requiredComponents)); }
 
             RequiredComponents = requiredComponents.ToArray();
 			ExcludedComponents = Array.Empty<Type>();
@@ -32,14 +30,10 @@ namespace EcsRx.Groups
 	    public Group(IEnumerable<Type> requiredComponents, IEnumerable<Type> excludedComponents)
 	    {
             if (requiredComponents is null)
-            {
-                throw new ArgumentNullException(nameof(requiredComponents));
-            }
+            { throw new ArgumentNullException(nameof(requiredComponents)); }
 
             if (excludedComponents is null)
-            {
-                throw new ArgumentNullException(nameof(excludedComponents));
-            }
+            { throw new ArgumentNullException(nameof(excludedComponents)); }
 
             RequiredComponents = requiredComponents.ToArray();
 		    ExcludedComponents = excludedComponents.ToArray();

--- a/src/EcsRx/Groups/Group.cs
+++ b/src/EcsRx/Groups/Group.cs
@@ -14,29 +14,22 @@ namespace EcsRx.Groups
 		/// <summary>
 		/// Hint: maybe consider using Group.Empty for better performance, unless you plan on changing the group afterwards.
 		/// </summary>
-		public Group() {
+		public Group()
+		{
 			RequiredComponents = Array.Empty<Type>();
 			ExcludedComponents = Array.Empty<Type>();
 		}
 
-		public Group(params Type[] requiredComponents) {
-            if (requiredComponents is null)
-            { throw new ArgumentNullException(nameof(requiredComponents)); }
-
-            RequiredComponents = requiredComponents.ToArray();
+		public Group(params Type[] requiredComponents)
+		{
+			RequiredComponents = requiredComponents?.ToArray() ?? Array.Empty<Type>();
 			ExcludedComponents = Array.Empty<Type>();
 		}
         
 	    public Group(IEnumerable<Type> requiredComponents, IEnumerable<Type> excludedComponents)
 	    {
-            if (requiredComponents is null)
-            { throw new ArgumentNullException(nameof(requiredComponents)); }
-
-            if (excludedComponents is null)
-            { throw new ArgumentNullException(nameof(excludedComponents)); }
-
-            RequiredComponents = requiredComponents.ToArray();
-		    ExcludedComponents = excludedComponents.ToArray();
+            RequiredComponents = requiredComponents?.ToArray() ?? Array.Empty<Type>();
+		    ExcludedComponents = excludedComponents?.ToArray() ?? Array.Empty<Type>();
 	    }
     }
 }

--- a/src/EcsRx/Groups/Group.cs
+++ b/src/EcsRx/Groups/Group.cs
@@ -14,13 +14,34 @@ namespace EcsRx.Groups
 		/// <summary>
 		/// Hint: maybe consider using Group.Empty for better performance, unless you plan on changing the group afterwards.
 		/// </summary>
-		public Group() {}
+		public Group() {
+			RequiredComponents = Array.Empty<Type>();
+			ExcludedComponents = Array.Empty<Type>();
+		}
 
-		public Group(params Type[] requiredComponents) : this(requiredComponents, Array.Empty<Type>()) {}
+		public Group(params Type[] requiredComponents) {
+            if (requiredComponents is null)
+            {
+                throw new ArgumentNullException(nameof(requiredComponents));
+            }
+
+            RequiredComponents = requiredComponents.ToArray();
+			ExcludedComponents = Array.Empty<Type>();
+		}
         
 	    public Group(IEnumerable<Type> requiredComponents, IEnumerable<Type> excludedComponents)
 	    {
-		    RequiredComponents = requiredComponents.ToArray();
+            if (requiredComponents is null)
+            {
+                throw new ArgumentNullException(nameof(requiredComponents));
+            }
+
+            if (excludedComponents is null)
+            {
+                throw new ArgumentNullException(nameof(excludedComponents));
+            }
+
+            RequiredComponents = requiredComponents.ToArray();
 		    ExcludedComponents = excludedComponents.ToArray();
 	    }
     }


### PR DESCRIPTION
This was one of the issues I was encountering with my game after updating from EcsRx 5.0.110 to 6.0.131.

In various places I doing something like this:
`new Group().WithoutComponent<Indestructable>()`

After the update I ended up with complaints about null which I were caused by the changes I contributed myself a while ago. I didn't intent to force people to stop doing things like that and forgot the initialization on the new empty constructor overload.
I merely wanted to provide that summary as a hint to them for the empty constructor only.

Consequently I also added some additional null checks.