### PR TITLE
improved error for incorrect component types

### DIFF
--- a/src/EcsRx.Tests/EcsRx/Components/Lookups/ComponentTypeLookupTests.cs
+++ b/src/EcsRx.Tests/EcsRx/Components/Lookups/ComponentTypeLookupTests.cs
@@ -1,0 +1,32 @@
+﻿using EcsRx.Components.Lookups;
+using EcsRx.Tests.Models;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace EcsRx.Tests.EcsRx.Components.Lookups
+{
+    public class ComponentTypeLookupTests
+    {
+        [Fact]
+        public void requesting_non_existing_component_type_throws_keynotfound()
+        {
+            var sut = new ComponentTypeLookup(new Dictionary<Type, int>());
+            Assert.Throws<KeyNotFoundException>(() => sut.GetComponentTypeId(typeof(TestComponentOne)));
+        }
+
+        [Fact]
+        public void requesting_existing_component_type_returns_expected_component_id()
+        {
+            var sut = new ComponentTypeLookup(new Dictionary<Type, int> { {typeof(ComponentWithoutInterface), 1} });
+            Assert.Equal(1, sut.GetComponentTypeId(typeof(ComponentWithoutInterface)));
+        }
+
+        [Fact]
+        public void requesting_non_existing_type_without_component_interface_throws_argumentexception()
+        {
+            var sut = new ComponentTypeLookup(new Dictionary<Type, int>());
+            Assert.Throws<ArgumentException>(() => sut.GetComponentTypeId(typeof(ComponentWithoutInterface)));
+        }
+    }
+}

--- a/src/EcsRx.Tests/Models/ComponentWithoutInterface.cs
+++ b/src/EcsRx.Tests/Models/ComponentWithoutInterface.cs
@@ -1,0 +1,6 @@
+﻿namespace EcsRx.Tests.Models
+{
+    public class ComponentWithoutInterface
+    {
+    }
+}

--- a/src/EcsRx/Components/Lookups/ComponentTypeLookup.cs
+++ b/src/EcsRx/Components/Lookups/ComponentTypeLookup.cs
@@ -28,7 +28,16 @@ namespace EcsRx.Components.Lookups
         }
 
         public int GetComponentTypeId(Type type)
-        { return ComponentsByType[type]; }
+        {
+            try
+            {
+                return ComponentsByType[type];
+            }
+            catch (KeyNotFoundException ex) when (!typeof(IComponent).IsAssignableFrom(type))
+            {
+                throw new ArgumentException($"The supplied {nameof(type)} doesn't implement {nameof(IComponent)}. Additionally, there was no componentId was assigned to it. type = {type}", nameof(type), ex);
+            }
+        }
 
         public Type GetComponentType(int typeId)
         { return ComponentsById[typeId]; }


### PR DESCRIPTION
I've been wanting to make this change for a very long time.
Every once in a while I've accidentally put the wrong type in a group. This can easily happen when some component types are mostly wrappers around another type with the ability to change over time (aka using a ReactiveProperty or something similar).

In a few instances the resulting exception didn't make me realize the nature of my mistake right away. So I think this should be a good quality of life improvement for others as well, going forward.