### PR TITLE
modified EntityDatabaseDataTransformer to correctly load json

### DIFF
--- a/src/EcsRx.Plugins.Persistence/Transformers/FromEntityDatabaseDataTransformer.cs
+++ b/src/EcsRx.Plugins.Persistence/Transformers/FromEntityDatabaseDataTransformer.cs
@@ -24,7 +24,15 @@ namespace EcsRx.Plugins.Persistence.Transformers
             entityDatabaseData.EntityCollections
                 .Select(EntityCollectionDataTransformer.Transform)
                 .Cast<IEntityCollection>()
-                .ForEachRun(entityDatabase.AddCollection);
+                .ForEachRun(x =>
+                {
+                    if (entityDatabase.Collections.Any(e => e.Id == x.Id))
+                    {
+                        entityDatabase.RemoveCollection(x.Id);
+                        
+                    }
+                    entityDatabase.AddCollection(x);
+                });
 
             return entityDatabase;
         }


### PR DESCRIPTION
after running the example "LoadingEntityDatabase" and adding some random entities, it correctly stores it in the json file. However when i tried to run it the second time, it throws when it tried to AddCollection because it already contained a collection with Id0 i suppose. 

Code submitted removes whatever has been taken, and load the json.

So I suppose a collection with id0 is automatically added to the EntityCollections no matter what?