### PR TITLE
Fixed ComputedGroup refresh firing unecessary remove events

### DIFF
--- a/src/EcsRx.Plugins.Computeds/Groups/ComputedGroup.cs
+++ b/src/EcsRx.Plugins.Computeds/Groups/ComputedGroup.cs
@@ -71,7 +71,7 @@ namespace EcsRx.Plugins.Computeds.Groups
         public void RefreshEntities()
         {
             var applicableEntities = InternalObservableGroup.Where(IsEntityApplicable).ToArray();
-            var entitiesToRemove = InternalObservableGroup.Where(x => applicableEntities.All(y => y.Id != x.Id)).ToArray();
+            var entitiesToRemove = CachedEntities.Where(x => applicableEntities.All(y => y.Id != x.Id)).ToArray();
             var entitiesToAdd = applicableEntities.Where(x => !CachedEntities.Contains(x.Id)).ToArray();
             
             for (var i = entitiesToAdd.Length - 1; i >= 0; i--)


### PR DESCRIPTION
Computed group was firing an EntityRemoved event on refresh for every entity within the InternalObservableGroup that did not meet the computed groups requirements.